### PR TITLE
Block missing host header requests

### DIFF
--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -30,6 +30,12 @@ http {
   }
 
   server {
+    listen      80;
+    server_name "";
+    return      444;
+  }
+
+  server {
     listen 80;
     charset     utf-8;
 


### PR DESCRIPTION
Closes #96

Currently, Django is responding to blank host header requests. It is better to not even allow it through according to [nginx](https://nginx.org/en/docs/http/request_processing.html#how_to_prevent_undefined_server_names).
This will stop messages to Sentry.

It is currently running on Beta as a test. Accessing Beta normally seems to be functioning properly.

Before:
```
$ http --verify no https://52.201.242.57
/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py:794: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Type: text/html
Date: Sat, 12 Aug 2017 04:34:50 GMT
Server: nginx/1.11.10
Transfer-Encoding: chunked
X-Sentry-ID: d4ab23dcdba4456fb63006701d14ba38
x-content-type-options: nosniff
x-xss-protection: 1; mode=block

<h1>Bad Request (400)</h1>
```
After:
```
$ http --verify no https://52.201.242.57

http: error: ConnectionError: HTTPSConnectionPool(host='52.201.242.57', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f576ca7bc10>: Failed to establish a new connection: [Errno 111] Connection refused',))
```