### PR TITLE
Block missing host header on 80 and 443 in the correct config file

### DIFF
--- a/compose/nginx/nginx-secure.conf
+++ b/compose/nginx/nginx-secure.conf
@@ -32,6 +32,13 @@ http {
     upstream app {
         server django:5000;
     }
+
+    server {
+        listen      80;
+        server_name "";
+        return      444;
+    }
+
     server {
         listen 80;
         server_name ___my.example.com___ www.___my.example.com___;
@@ -50,6 +57,12 @@ http {
             return         301 https://$server_name$request_uri;
         }
 
+    }
+
+    server {
+        listen      443;
+        server_name "";
+        return      444;
     }
 
     server {


### PR DESCRIPTION
Closes #96 