### PR TITLE
Fix broken nginx blocking of missing host header

### DIFF
--- a/compose/nginx/nginx-secure.conf
+++ b/compose/nginx/nginx-secure.conf
@@ -34,12 +34,6 @@ http {
     }
 
     server {
-        listen      80;
-        server_name "";
-        return      444;
-    }
-
-    server {
         listen 80;
         server_name ___my.example.com___ www.___my.example.com___;
 
@@ -57,12 +51,6 @@ http {
             return         301 https://$server_name$request_uri;
         }
 
-    }
-
-    server {
-        listen      443;
-        server_name "";
-        return      444;
     }
 
     server {
@@ -104,6 +92,28 @@ http {
 
         }
 
+    }
+
+    server {
+        listen 80 default_server;
+        return 444;
+    }
+
+    server {
+        listen 443 default_server;
+
+        ssl on;
+        ssl_certificate /etc/letsencrypt/live/___my.example.com___/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/___my.example.com___/privkey.pem;
+        ssl_session_timeout 5m;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+        ssl_prefer_server_ciphers on;
+
+        ssl_session_cache shared:SSL:10m;
+        ssl_dhparam /etc/ssl/private/dhparams.pem;
+
+        return 444;
     }
 
 }


### PR DESCRIPTION
Closes #96 

The secure port block requires SSL configuration. Connecting to `beta.rovercode.com` still functions correctly.

Client:
```
$ http --verify no https://52.201.242.57
/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py:794: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)

http: error: ConnectionError: ('Connection aborted.', BadStatusLine("''",))

$ http http://52.201.242.57             
http: error: ConnectionError: ('Connection aborted.', BadStatusLine("''",))
```

Server:
```
nginx_1     | 73.168.181.206 - - [13/Aug/2017:00:19:26 +0000] "beta.rovercode.com" "GET / HTTP/1.1" 200 3329 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.39 Safari/537.36" "-"
nginx_1     | 73.168.181.206 - - [13/Aug/2017:00:19:33 +0000] "" "GET / HTTP/1.1" 444 0 "-" "HTTPie/0.9.2" "-"
nginx_1     | 73.168.181.206 - - [13/Aug/2017:00:19:39 +0000] "" "GET / HTTP/1.1" 444 0 "-" "HTTPie/0.9.2" "-"