### PR TITLE
Point to newer certbot image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,8 @@ services:
       - /var/lib/letsencrypt:/var/lib/letsencrypt
 
   certbot:
-    image: quay.io/letsencrypt/letsencrypt
-    command: bash -c "sleep 6 && certbot certonly -n --standalone -d rovercode.com --text --agree-tos --email bradyhurlburt@gmail.com --server https://acme-v01.api.letsencrypt.org/directory --rsa-key-size 4096 --verbose --keep-until-expiring --standalone-supported-challenges http-01"
+    image: certbot/certbot 
+    command: sh -c "sleep 6 && certbot certonly -n --standalone -d rovercode.com --text --agree-tos --email bradyhurlburt@gmail.com --server https://acme-v01.api.letsencrypt.org/directory --rsa-key-size 4096 --verbose --keep-until-expiring --standalone-supported-challenges http-01"
     entrypoint: ""
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt


### PR DESCRIPTION
The certificate was failing to update on the live servers, and this change seems to have fixed it. LetsEncrypt switched to a new image location/name on DockerHub, and apparently stopped updating the old one.