### PR TITLE
Backend OAuth Integration

### DIFF
--- a/api/apps.py
+++ b/api/apps.py
@@ -1,5 +1,21 @@
 """API apps."""
 from django.apps import AppConfig
+from django.dispatch import receiver
+from oauth2_provider.signals import app_authorized
+
+
+@receiver(app_authorized)
+def handle_app_authorized(sender, request, token, **kwargs):
+    """Attach the application's user to the token.
+
+    When using `client_credentials`, there isn't a user attached to an access
+    token. This causes Django Rest Framework to fail to authorize when using
+    the provided access token. Connecting the application's user to the token
+    means that any requests made using the access token will be made as the
+    user.
+    """
+    token.user = token.application.user
+    token.save()
 
 
 class ApiConfig(AppConfig):

--- a/api/tests/test_apps.py
+++ b/api/tests/test_apps.py
@@ -1,0 +1,62 @@
+"""API test apps."""
+from django.contrib.auth import get_user_model
+from django.core.urlresolvers import reverse
+
+from test_plus.test import TestCase
+
+from mission_control.models import Rover
+from oauth2_provider.models import Application
+
+
+class TestApiApps(TestCase):
+    """Tests the apps."""
+
+    def test_access_token(self):
+        """Test access token can access API."""
+        admin = get_user_model().objects.create_user(
+            username='administrator',
+            email='admin@example.com',
+            password='password'
+        )
+
+        app = Application.objects.create(
+            user=admin,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            name='Sparky'
+        )
+
+        token_info = {
+            'grant_type': 'client_credentials',
+            'client_id': app.client_id,
+            'client_secret': app.client_secret,
+        }
+
+        response = self.client.post(
+            reverse('oauth2_provider:token'), token_info)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('access_token', response.json())
+
+        access_token = response.json()['access_token']
+
+        Rover.objects.create(
+            name='rover',
+            owner=admin,
+            local_ip='8.8.8.8'
+        )
+        Rover.objects.create(
+            name='rover2',
+            owner=self.make_user(),
+            local_ip='8.8.8.8'
+        )
+
+        response = self.client.get(
+            reverse('api:v1:rover-list'),
+            HTTP_AUTHORIZATION='Bearer {0}'.format(access_token))
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, len(response.json()))
+        self.assertEqual(response.json()[0]['name'], 'rover')
+        self.assertEqual(response.json()[0]['owner'], admin.id)
+        self.assertEqual(response.json()[0]['local_ip'], '8.8.8.8')

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -41,6 +41,7 @@ THIRD_PARTY_APPS = (
     'allauth.account',  # registration
     'allauth.socialaccount',  # registration
     'rest_framework',
+    'oauth2_provider',
 )
 
 # Apps specific for this project go here.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -67,6 +67,7 @@ MIDDLEWARE = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'oauth2_provider.middleware.OAuth2TokenMiddleware',
 )
 
 # MIGRATIONS CONFIGURATION
@@ -235,6 +236,7 @@ AUTH_PASSWORD_VALIDATORS = [
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
     'allauth.account.auth_backends.AuthenticationBackend',
+    'oauth2_provider.backends.OAuth2Backend',
 )
 
 # Some really nice defaults
@@ -261,3 +263,22 @@ ADMIN_URL = r'^admin/'
 
 # Your common stuff: Below this line define 3rd party library settings
 # ------------------------------------------------------------------------------
+
+# OAUTH2 PROVIDER CONFIGURATION
+# ------------------------------------------------------------------------------
+OAUTH2_PROVIDER = {
+    'SCOPES': {
+        'read': 'Read scope',
+        'write': 'Write scope',
+    }
+}
+
+# REST FRAMEWORK CONFIGURATION
+# ------------------------------------------------------------------------------
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.BasicAuthentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
+    ),
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     url(r'^api/', include('api.urls', namespace='api')),
     url(r'^api-auth/',
         include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,3 +49,6 @@ djangorestframework~=3.5.3
 django-filter==1.0.1
 pylint==1.6.5
 prospector==0.12.4
+
+# Using signals added after the 1.0.0 release
+git+https://github.com/evonove/django-oauth-toolkit.git@18bbdc177f5f68f7db173bd3b883787418816a81#egg=django-oauth-toolkit


### PR DESCRIPTION
Handles the backend parts of #82.

Next, we need to figure out how we want to integrate this into the UI. Currently, just uses the default templates from [Django OAuth Toolkit](https://github.com/evonove/django-oauth-toolkit).

**New URLs**
```
/oauth2/applications/	oauth2_provider.views.application.ApplicationList	oauth2_provider:list	
/oauth2/applications/<pk>/	oauth2_provider.views.application.ApplicationDetail	oauth2_provider:detail	
/oauth2/applications/<pk>/delete/	oauth2_provider.views.application.ApplicationDelete	oauth2_provider:delete	
/oauth2/applications/<pk>/update/	oauth2_provider.views.application.ApplicationUpdate	oauth2_provider:update	
/oauth2/applications/register/	oauth2_provider.views.application.ApplicationRegistration	oauth2_provider:register	
/oauth2/authorize/	oauth2_provider.views.base.AuthorizationView	oauth2_provider:authorize	
/oauth2/authorized_tokens/	oauth2_provider.views.token.AuthorizedTokensListView	oauth2_provider:authorized-token-list	
/oauth2/authorized_tokens/<pk>/delete/	oauth2_provider.views.token.AuthorizedTokenDeleteView	oauth2_provider:authorized-token-delete	
/oauth2/introspect/	oauth2_provider.views.introspect.IntrospectTokenView	oauth2_provider:introspect	
/oauth2/revoke_token/	oauth2_provider.views.base.RevokeTokenView	oauth2_provider:revoke-token	
/oauth2/token/	oauth2_provider.views.base.TokenView	oauth2_provider:token	
```
**Create an application**
![image](https://user-images.githubusercontent.com/1184314/30253067-aba6cdec-964b-11e7-833d-acfd088dfbc4.png)
![image](https://user-images.githubusercontent.com/1184314/30253075-f20116f8-964b-11e7-85c6-d25ff77b729d.png)
_We'll want to hide all the options except for `Name`_
**Obtain credentials for application**
![image](https://user-images.githubusercontent.com/1184314/30253086-2a00be64-964c-11e7-9abf-9a123afbaccf.png)
**From the Rover, use credentials to obtain an access token**
```
$ http --verbose -f POST http://localhost:8000/oauth2/token/ grant_type=client_credentials client_id=ZXhNNFMBuLYiuLXEsGFHLh4XFo2mNMd5XFJHdWdU client_secret=HCYbSCC6aGZbiiaOYXAW3KWSb8ue2JO1Cqa1VB3EXLhklLn9SGCBTPYYMqzpaTkDUhevTgTdSnPJkoSwPqnLuQxXkv2DsWz8hm7dbtqO4aDDop4LitGMzw2h0PCMxd9G
POST /oauth2/token/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 223
Content-Type: application/x-www-form-urlencoded; charset=utf-8
Host: localhost:8000
User-Agent: HTTPie/0.9.2

grant_type=client_credentials&client_id=ZXhNNFMBuLYiuLXEsGFHLh4XFo2mNMd5XFJHdWdU&client_secret=HCYbSCC6aGZbiiaOYXAW3KWSb8ue2JO1Cqa1VB3EXLhklLn9SGCBTPYYMqzpaTkDUhevTgTdSnPJkoSwPqnLuQxXkv2DsWz8hm7dbtqO4aDDop4LitGMzw2h0PCMxd9G

HTTP/1.0 200 OK
Cache-Control: no-store
Connection: close
Content-Type: application/json
Date: Sun, 10 Sep 2017 21:20:27 GMT
Pragma: no-cache
Server: Werkzeug/0.11.15 Python/3.5.4
Vary: Authorization
X-Frame-Options: SAMEORIGIN

{
    "access_token": "cSVmBlCfD9aAWMSlbVPBlpy5nAiEqg", 
    "expires_in": 36000, 
    "scope": "read write", 
    "token_type": "Bearer"
}
```
**From the Rover, make API calls using the access token**
```
$ http --verbose http://localhost:8000/api/v1/rovers/ Authorization:"Bearer cSVmBlCfD9aAWMSlbVPBlpy5nAiEqg"
GET /api/v1/rovers/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: Bearer cSVmBlCfD9aAWMSlbVPBlpy5nAiEqg
Connection: keep-alive
Host: localhost:8000
User-Agent: HTTPie/0.9.2



HTTP/1.0 200 OK
Allow: GET, POST, OPTIONS
Connection: close
Content-Type: application/json
Date: Sun, 10 Sep 2017 21:22:30 GMT
Server: Werkzeug/0.11.15 Python/3.5.4
Vary: Accept, Authorization, Cookie
X-Frame-Options: SAMEORIGIN

[
    {
        "id": 2, 
        "last_checkin": "2017-09-10T21:22:27.698442Z", 
        "left_backward_pin": "XIO-P1", 
        "left_eye_pin": "XIO-P2", 
        "left_forward_pin": "XIO-P0", 
        "local_ip": "8.8.8.8", 
        "name": "Sparky", 
        "owner": 2, 
        "right_backward_pin": "XIO-P7", 
        "right_eye_pin": "XIO-P4", 
        "right_forward_pin": "XIO-P6"
    }
]
```
**An invalid token is blocked**
```
$ http --verbose http://localhost:8000/api/v1/rovers/ Authorization:"Bearer abc"                           
GET /api/v1/rovers/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: Bearer abc
Connection: keep-alive
Host: localhost:8000
User-Agent: HTTPie/0.9.2



HTTP/1.0 403 Forbidden
Allow: GET, POST, OPTIONS
Connection: close
Content-Type: application/json
Date: Sun, 10 Sep 2017 21:24:43 GMT
Server: Werkzeug/0.11.15 Python/3.5.4
Vary: Accept, Authorization, Cookie
X-Frame-Options: SAMEORIGIN

{
    "detail": "Authentication credentials were not provided."
}
```