### PR TITLE
Add form to create new rover

### DIFF
--- a/mission_control/forms.py
+++ b/mission_control/forms.py
@@ -6,6 +6,21 @@ from .models import Rover
 class RoverForm(forms.ModelForm):
     """Fields for modifying rover settings."""
 
+    name = forms.CharField(
+        widget=forms.TextInput(attrs={'class': 'form-control'}))
+    left_forward_pin = forms.CharField(
+        widget=forms.TextInput(attrs={'class': 'form-control'}))
+    left_backward_pin = forms.CharField(
+        widget=forms.TextInput(attrs={'class': 'form-control'}))
+    right_forward_pin = forms.CharField(
+        widget=forms.TextInput(attrs={'class': 'form-control'}))
+    right_backward_pin = forms.CharField(
+        widget=forms.TextInput(attrs={'class': 'form-control'}))
+    left_eye_pin = forms.CharField(
+        widget=forms.TextInput(attrs={'class': 'form-control'}))
+    right_eye_pin = forms.CharField(
+        widget=forms.TextInput(attrs={'class': 'form-control'}))
+
     class Meta:
         """Meta class."""
 

--- a/mission_control/templates/rover_list.html
+++ b/mission_control/templates/rover_list.html
@@ -17,6 +17,9 @@
   </div>
   <div class="row">
     <div class="col-md-12 btn-group" id="bds">
+      <button class="btn btn-large btn-info" onclick="location.href = '{% url 'mission-control:rover_new' %}';">
+        Register a New Rover
+      </button>
       {% for rover in rover_list %}
         <button class="btn btn-primary" onclick="location.href = '{% url 'mission-control:rover_settings' pk=rover.pk %}';">
           {{ rover.name }}

--- a/mission_control/templates/rover_list.html
+++ b/mission_control/templates/rover_list.html
@@ -16,10 +16,14 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-12 btn-group" id="bds">
+    <div class="col-md-12 btn-group">
       <button class="btn btn-large btn-info" onclick="location.href = '{% url 'mission-control:rover_new' %}';">
         Register a New Rover
       </button>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12 btn-group" id="bds">
       {% for rover in rover_list %}
         <button class="btn btn-primary" onclick="location.href = '{% url 'mission-control:rover_settings' pk=rover.pk %}';">
           {{ rover.name }}

--- a/mission_control/templates/rover_settings.html
+++ b/mission_control/templates/rover_settings.html
@@ -13,15 +13,19 @@
 {% block content %}
   <div class="row">
     <div class="col-md-12">
-      <h1>{{ name }}'s Settings:</h1>
+      {% if name and name.strip %}
+        <h1>{{ name }}'s Settings:</h1>
+      {% else %}
+        <h1>New Rover:</h1>
+      {% endif %}
     </div>
   </div>
   <div class="row">
     <div class="col-md-12">
       <h4 for="sbc">{% trans "Single Board Computer:" %}</h4>
     </div>
-   </div>
-  <div class="row">
+  </div>
+  <div class="row" style="padding-bottom: 1em;">
     <div class="col-md-12">
       <select class="form-control" id="sbc" disabled>
         <option>Next Thing Co. CHIP</option>
@@ -39,22 +43,12 @@
     <div class="col-md-12">
       <form method="post">
         {% csrf_token %}
-        <div class="form-group row">
-          {{ form.as_p }}
-        </div>
-        <div class="form-group row">
-          <button type="submit" class="btn btn-primary">Save</button>
-        </div>
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-primary">Save</button>
       </form>
     </div>
   </div>
 {% endblock content %}
 
 {% block javascript %}
-{{ block.super }}
-  <script>
-  $(document).ready(function() {
-    $("input[id=id_name]").attr("disabled", true)
-  });
-  </script>
 {% endblock javascript %}

--- a/mission_control/tests/test_urls.py
+++ b/mission_control/tests/test_urls.py
@@ -64,3 +64,15 @@ class TestMissionControlURLs(TestCase):
         self.assertEqual(
             resolve('/mission-control/rover-settings/1/').view_name,
             'mission-control:rover_settings')
+
+    def test_rover_new_reverse(self):
+        """'mission-control:rover_new' should reverse to /mission-control/rover-settings/.""" # noqa
+        self.assertEqual(
+            reverse('mission-control:rover_new'),
+            '/mission-control/rover-settings/')
+
+    def test_rover_new_resolve(self):
+        """/mission-control/rover-settings/ should resolve to mission-control:rover_new."""  # noqa
+        self.assertEqual(
+            resolve('/mission-control/rover-settings/').view_name,
+            'mission-control:rover_new')

--- a/mission_control/tests/test_views.py
+++ b/mission_control/tests/test_views.py
@@ -131,7 +131,7 @@ class TestRoverSettingsView(BaseAuthenticatedTestCase):
         self.assertContains(response, 'New Rover')
 
     def test_new_rover_save(self):
-        """Test getting a form for a new rover."""
+        """Test creating a new rover."""
         self.client.login(username='administrator', password='password')
         settings = {
             'name': 'rover123',

--- a/mission_control/tests/test_views.py
+++ b/mission_control/tests/test_views.py
@@ -123,6 +123,48 @@ class TestRoverListView(BaseAuthenticatedTestCase):
 class TestRoverSettingsView(BaseAuthenticatedTestCase):
     """Tests the rover settings view."""
 
+    def test_new_rover_form(self):
+        """Test getting a form for a new rover."""
+        self.client.login(username='administrator', password='password')
+        response = self.get(reverse('mission-control:rover_new'))
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, 'New Rover')
+
+    def test_new_rover_save(self):
+        """Test getting a form for a new rover."""
+        self.client.login(username='administrator', password='password')
+        settings = {
+            'name': 'rover123',
+            'left_forward_pin': 'a',
+            'left_backward_pin': 'b',
+            'right_forward_pin': 'c',
+            'right_backward_pin': 'd',
+            'left_eye_pin': 'e',
+            'right_eye_pin': 'f',
+            'local_ip': '192.169.1.200',
+        }
+        response = self.client.post(
+            reverse('mission-control:rover_new'),
+            settings)
+        self.assertRedirects(
+            response,
+            reverse('mission-control:rover_list'))
+        rover_obj = Rover.objects.get(name='rover123')
+        self.assertEqual(rover_obj.owner, self.admin)
+        self.assertEqual(rover_obj.name, settings['name'])
+        self.assertEqual(
+            rover_obj.left_forward_pin, settings['left_forward_pin'])
+        self.assertEqual(
+            rover_obj.right_forward_pin, settings['right_forward_pin'])
+        self.assertEqual(
+            rover_obj.left_backward_pin, settings['left_backward_pin'])
+        self.assertEqual(
+            rover_obj.right_backward_pin, settings['right_backward_pin'])
+        self.assertEqual(
+            rover_obj.left_eye_pin, settings['left_eye_pin'])
+        self.assertEqual(
+            rover_obj.right_eye_pin, settings['right_eye_pin'])
+
     def test_display_settings(self):
         """Test the rover settings view displays the correct items."""
         self.client.login(username='administrator', password='password')

--- a/mission_control/urls.py
+++ b/mission_control/urls.py
@@ -13,4 +13,6 @@ urlpatterns = [
     url(r'^rover-list/$', views.rover_list, name='rover_list'),
     url(r'^rover-settings/(?P<pk>[0-9]+)/$',
         views.rover_settings, name='rover_settings'),
+    url(r'^rover-settings/$',
+        views.rover_settings, name='rover_new'),
 ]

--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -37,10 +37,12 @@ def rover_list(request):
 
 
 @login_required
-def rover_settings(request, pk):
+def rover_settings(request, pk=None):
     """Rover settings view for the specific rover."""
-    rover = get_object_or_404(Rover, owner=request.user, pk=pk)
-    print(request.POST)
+    if pk:
+        rover = get_object_or_404(Rover, owner=request.user, pk=pk)
+    else:
+        rover = Rover(owner=request.user, pk=pk)
     if request.method == 'POST':
         form = RoverForm(instance=rover, data=request.POST)
 
@@ -48,9 +50,7 @@ def rover_settings(request, pk):
             form.save()
             return redirect(reverse('mission-control:rover_list'))
 
-        form = RoverForm(instance=rover)
-    else:
-        form = RoverForm(instance=rover)
+    form = RoverForm(instance=rover)
 
     return render(request, 'rover_settings.html', {
         'name': rover.name,

--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -42,7 +42,7 @@ def rover_settings(request, pk=None):
     if pk:
         rover = get_object_or_404(Rover, owner=request.user, pk=pk)
     else:
-        rover = Rover(owner=request.user, pk=pk)
+        rover = Rover(owner=request.user)
     if request.method == 'POST':
         form = RoverForm(instance=rover, data=request.POST)
 


### PR DESCRIPTION
Partially addresses #105.

Adds page to create new rover, with a button to get there.

Also, make the rover settings form use bootstrap form-control.

Still to do: add a relationship between the rover model and the rover OAuth model, and make the new-rover view also create the OAuth model. 