### PR TITLE
Use correct error method name for $.get()

### DIFF
--- a/mission_control/static/js/bd-api.js
+++ b/mission_control/static/js/bd-api.js
@@ -117,7 +117,7 @@ function downloadDesign(name) {
     .attr( {'download': name, 'href': downloadUrl} )
     .get(0)
     .click();
-  }).error(function() {
+  }).fail(function() {
     alert("There was an error accessing your design");
   });
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,6 +48,7 @@ redis>=2.10.5
 djangorestframework~=3.5.3
 django-filter==1.0.1
 pylint==1.6.5
+pylint-django==0.8.0
 prospector==0.12.4
 
 # Using signals added after the 1.0.0 release


### PR DESCRIPTION
Ran into this when trying to download a block diagram. It always fails because of #117 but this fixes the error handling associated with a failure.