### PR TITLE
Add client_id to rover model serialization

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -97,7 +97,7 @@ class TestRoverViewSet(BaseAuthenticatedTestCase):
     def test_rover_not_logged_in(self):
         """Test the rover view denies unauthenticated user."""
         response = self.get(reverse('api:v1:rover-list'))
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(401, response.status_code)
 
 
 class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
@@ -156,7 +156,7 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
     def test_bd_not_logged_in(self):
         """Test the block diagram view denies unauthenticated user."""
         response = self.get(reverse('api:v1:blockdiagram-list'))
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(401, response.status_code)
 
     def test_bd_create(self):
         """Test creating block diagram sets user."""

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -278,8 +278,8 @@ OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 # ------------------------------------------------------------------------------
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
-        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
     ),
 }

--- a/mission_control/serializers.py
+++ b/mission_control/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 
 class RoverSerializer(serializers.ModelSerializer):
     """Rover model serializer."""
-
+    client_id = serializers.CharField(source='oauth_application.client_id', read_only=True)
     class Meta:
         """Meta class."""
 
@@ -14,6 +14,7 @@ class RoverSerializer(serializers.ModelSerializer):
             'id', 'name', 'owner', 'local_ip', 'last_checkin',
             'left_forward_pin', 'left_backward_pin', 'right_forward_pin',
             'right_backward_pin', 'left_eye_pin', 'right_eye_pin',
+            'client_id',
         )
         read_only_fields = ('owner',)
 

--- a/mission_control/serializers.py
+++ b/mission_control/serializers.py
@@ -5,7 +5,10 @@ from rest_framework import serializers
 
 class RoverSerializer(serializers.ModelSerializer):
     """Rover model serializer."""
-    client_id = serializers.CharField(source='oauth_application.client_id', read_only=True)
+
+    client_id = serializers.CharField(source='oauth_application.client_id',
+                                      read_only=True)
+
     class Meta:
         """Meta class."""
 


### PR DESCRIPTION
This allows the rover to query the API for itself by client_id instead of by name, eliminating the need
for the name to be in the .env