### PR TITLE
Add beta deploy on new server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,26 +23,37 @@ language: python
 python:
 - '3.5'
 deploy:
-- provider: codedeploy
-  access_key_id: AKIAIZTZIW2KWAYZ6MUQ
-  secret_access_key:
-    secure: KTdHFUfomQvGqnulNo+K6IaVdl/WIuKvhvFNkXEfYOdfn4kWL0vf7F1aarhWN+Ptcj5QCiqpsa6KNi4U+f5J2K2xQUa4wZmQa1gLkw5l6Uaw9zbpbB3I4nywjGfNtPRKAwc8caQ80EaaSBHl3GsgJnTFszWkhWmY4k6bfvLLconLtRXFB07YS9mqwq6CvZ40RBiI2rUW1zgYGz6FRJhd0k/QGCqv3k+D3sPYad8/e3yapOhDTIFJESUMQt94rmg4n2gYBJMggk+aZ2yarSV7mr9Samf3HnGZ1VbONqsEH1rKlDsR9uT77udv8scryJDWlVyCAWpwr8y1Od2b6+VbWayWBY/xoPoeQLsQoReI6fzQy4fgk24F+Yxe5dxvSBkeil5Vq1yBKpBhxq53+Mto8mKTFXa0/6uNMD7JN+0kl6kbJVrIULhpd3/QYtF7DH2TYMhWsO0duGwz4k/IpsDMWddsIVrxCiaEKMKpD8ZY5WlV8Qun72/wlRaC557upK+LVJm89WntCEypoPEHNWYvzulVe0weWVlv89053ryP7rHa5PUwh8N0NLwI9dxAJ7WcgXjuiaZCtqLsbIXCpBOECstWFS8Kd/FS6Y3Tp4CRIN0Jt80BciKFV5HTyYWPsXnaFqNmt/PyRHkwgdIj4ULo2xLNAyXUQGS4RoPSdBVh9O4=
-  revision_type: github
-  application: beta-rovercode-web
-  deployment_group: beta-rovercode-web
-  on:
-    repo: rovercode/rovercode-web
-    branch: development
-- provider: codedeploy
-  access_key_id: AKIAIZTZIW2KWAYZ6MUQ
-  secret_access_key:
-    secure: KTdHFUfomQvGqnulNo+K6IaVdl/WIuKvhvFNkXEfYOdfn4kWL0vf7F1aarhWN+Ptcj5QCiqpsa6KNi4U+f5J2K2xQUa4wZmQa1gLkw5l6Uaw9zbpbB3I4nywjGfNtPRKAwc8caQ80EaaSBHl3GsgJnTFszWkhWmY4k6bfvLLconLtRXFB07YS9mqwq6CvZ40RBiI2rUW1zgYGz6FRJhd0k/QGCqv3k+D3sPYad8/e3yapOhDTIFJESUMQt94rmg4n2gYBJMggk+aZ2yarSV7mr9Samf3HnGZ1VbONqsEH1rKlDsR9uT77udv8scryJDWlVyCAWpwr8y1Od2b6+VbWayWBY/xoPoeQLsQoReI6fzQy4fgk24F+Yxe5dxvSBkeil5Vq1yBKpBhxq53+Mto8mKTFXa0/6uNMD7JN+0kl6kbJVrIULhpd3/QYtF7DH2TYMhWsO0duGwz4k/IpsDMWddsIVrxCiaEKMKpD8ZY5WlV8Qun72/wlRaC557upK+LVJm89WntCEypoPEHNWYvzulVe0weWVlv89053ryP7rHa5PUwh8N0NLwI9dxAJ7WcgXjuiaZCtqLsbIXCpBOECstWFS8Kd/FS6Y3Tp4CRIN0Jt80BciKFV5HTyYWPsXnaFqNmt/PyRHkwgdIj4ULo2xLNAyXUQGS4RoPSdBVh9O4=
-  revision_type: github
-  application: rovercode-web
-  deployment_group: rovercode-web
-  on:
-    repo: rovercode/rovercode-web
-    branch: master
+  matrix:
+  - provider: codedeploy
+    access_key_id: AKIAIZTZIW2KWAYZ6MUQ
+    secret_access_key:
+      secure: KTdHFUfomQvGqnulNo+K6IaVdl/WIuKvhvFNkXEfYOdfn4kWL0vf7F1aarhWN+Ptcj5QCiqpsa6KNi4U+f5J2K2xQUa4wZmQa1gLkw5l6Uaw9zbpbB3I4nywjGfNtPRKAwc8caQ80EaaSBHl3GsgJnTFszWkhWmY4k6bfvLLconLtRXFB07YS9mqwq6CvZ40RBiI2rUW1zgYGz6FRJhd0k/QGCqv3k+D3sPYad8/e3yapOhDTIFJESUMQt94rmg4n2gYBJMggk+aZ2yarSV7mr9Samf3HnGZ1VbONqsEH1rKlDsR9uT77udv8scryJDWlVyCAWpwr8y1Od2b6+VbWayWBY/xoPoeQLsQoReI6fzQy4fgk24F+Yxe5dxvSBkeil5Vq1yBKpBhxq53+Mto8mKTFXa0/6uNMD7JN+0kl6kbJVrIULhpd3/QYtF7DH2TYMhWsO0duGwz4k/IpsDMWddsIVrxCiaEKMKpD8ZY5WlV8Qun72/wlRaC557upK+LVJm89WntCEypoPEHNWYvzulVe0weWVlv89053ryP7rHa5PUwh8N0NLwI9dxAJ7WcgXjuiaZCtqLsbIXCpBOECstWFS8Kd/FS6Y3Tp4CRIN0Jt80BciKFV5HTyYWPsXnaFqNmt/PyRHkwgdIj4ULo2xLNAyXUQGS4RoPSdBVh9O4=
+    revision_type: github
+    application: beta-rovercode-web
+    deployment_group: beta-rovercode-web
+    on:
+      repo: rovercode/rovercode-web
+      branch: development
+  - provider: codedeploy
+    access_key_id: AKIAIZTZIW2KWAYZ6MUQ
+    secret_access_key:
+      secure: KTdHFUfomQvGqnulNo+K6IaVdl/WIuKvhvFNkXEfYOdfn4kWL0vf7F1aarhWN+Ptcj5QCiqpsa6KNi4U+f5J2K2xQUa4wZmQa1gLkw5l6Uaw9zbpbB3I4nywjGfNtPRKAwc8caQ80EaaSBHl3GsgJnTFszWkhWmY4k6bfvLLconLtRXFB07YS9mqwq6CvZ40RBiI2rUW1zgYGz6FRJhd0k/QGCqv3k+D3sPYad8/e3yapOhDTIFJESUMQt94rmg4n2gYBJMggk+aZ2yarSV7mr9Samf3HnGZ1VbONqsEH1rKlDsR9uT77udv8scryJDWlVyCAWpwr8y1Od2b6+VbWayWBY/xoPoeQLsQoReI6fzQy4fgk24F+Yxe5dxvSBkeil5Vq1yBKpBhxq53+Mto8mKTFXa0/6uNMD7JN+0kl6kbJVrIULhpd3/QYtF7DH2TYMhWsO0duGwz4k/IpsDMWddsIVrxCiaEKMKpD8ZY5WlV8Qun72/wlRaC557upK+LVJm89WntCEypoPEHNWYvzulVe0weWVlv89053ryP7rHa5PUwh8N0NLwI9dxAJ7WcgXjuiaZCtqLsbIXCpBOECstWFS8Kd/FS6Y3Tp4CRIN0Jt80BciKFV5HTyYWPsXnaFqNmt/PyRHkwgdIj4ULo2xLNAyXUQGS4RoPSdBVh9O4=
+    revision_type: github
+    application: rovercode-web
+    deployment_group: rovercode-web
+    on:
+      repo: rovercode/rovercode-web
+      branch: master
+  - provider: codedeploy
+    access_key_id: AKIAIGOTYWNVPHOL5OGQ
+    secret_access_key:
+      secure: UUvcBDt3HDSzlCvQwuPvUh+2YFgiq0ou+fYqWWebcmEC8rEPJo4CTv4OkmqH7TejOTVepQsPI+grbdUG3ktRKJ9qHIi7Z2s3R7qDvXcb8KDoLdhYHoHVq0i/DQthNrlPuYJCaIU0WVs1wjcGbPK3xw5deP7yQIDvaeQa1ZCTBg1JbI08rtQ0iiZgklOKd1amSayneu7k48BxKbkUSJrpEJXy5y0eJKBfV5hhzuYeksguG9sZH0UuuUochXHzWJMyR0nQtUPLdnrIWGHJGYvYOTt05L/9cre6uc8Va/iJKm1ui2/nDgJNbTgE8WcfLjT4uCrTbQEBv/LSZ5X3inDVctAq3lrMBuyJOsjOlZ5ZidQ7MGWKo4tPTlxIILOsk/IhDn7YTzN1rzb5hOGJLWjid4EfRApm0pJW6A9TvuaO7zYBokSoGe47hMKVuOSfpCw3xQV2QScy6Ptf4ErSmjZ+9bMLA6Cn+Aav33upn7xPef0g/g1J31lYjP0W1YUU+hLiwACidJ/Ykdp8ksHW818D/qiePsfTgq+Q7JAOUkrTeb/Ad/3fJIcTFOaGnWAxtgtbxpKRUWARiwI8oxSaXIOx5dS4LV59t2zsiZ0Wvp+o7ql3BoD8HyLAEY1BF7a6QPLmUoEjJUeOo0qyN9GC7jEQy4Jfb4sbNTokc9MCe+Szq0U=
+    revision_type: github
+    application: beta-rovercode-web
+    deployment_group: rovercode-web
+    on:
+      repo: rovercode/rovercode-web
+      branch: development
 notifications:
   slack:
     secure: lGfSdmE+gADEOsBsS1tu1jFkhrGqpAZlIUMMXFYjCPODfwrkTC9onyimKzUYOzDcEvOVP4uNQo5XFIZD5/dOg/Grjav9THvwADLuAumkMk9iH4tetWQ1KBRMawTxmMHUQa7ujoOERuEttrq4FhDo84RNaK8d+eLO8iuhHDGeqTd4MSgAak1aukCiohRKfvgNBNAlPPaiBKbeuSea+j46pRqhC/FM55cpIV9iiH0AhFIC9HKa3UkhHfNXh7fybTQuVVD0r+SOCbnJxQvIOzwjWQco+HjZXgXn62GSFLX4bW2WmqfFKuTiLhzXuLKXr5ZI6ggBlqaANvqCsv4Ki8yQ9/qsQOVUipZAnFzvMCAL1XGIBJdRO9mzBegzDk/QO538jOcPzK2P24abEvESqgC3Ld4JOcv1H6ZJ8dFVxnbCPcZIhgE6HoGD+8YHyFoZ5MvR6xq0cQfd7lmXPDgiYXnoQXwsx1Zd95hH07P+BQlsCFfhyG/T0QuXg6XIE7c5NdbZoZutxAbjPjOCJMWNRQlp20PWD+ms9QUNTvtcwtOsubobtoDi0mDSLK/RB6gvUEJkYSh6zmKoIYGLooXSeE8VnZ82V3RgzGnvNPSI8qpd+44czgpRcFtnATdmTw+zrxSywCCXhl9OODB2M4cxvZ7Vfgz2EQfb4taOxH8LibYEyQQ=


### PR DESCRIPTION
This adds a new deployment to Travis: beta-rovercode-web on our new AWS account.

The diff really botched it. Nothing changed except the addition of the new deploy block.