### PR TITLE
Add env vars to allow other postgres targets

### DIFF
--- a/compose/django/Dockerfile
+++ b/compose/django/Dockerfile
@@ -2,6 +2,11 @@ FROM python:3.5
 
 ENV PYTHONUNBUFFERED 1
 
+RUN apt-get install -y ca-certificates wget \
+    && wget https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem -P /usr/local/share/ca-certificates/ \
+    && mv /usr/local/share/ca-certificates/rds-ca-2015-root.pem /usr/local/share/ca-certificates/rds-ca-2015-root.crt \
+    && update-ca-certificates
+
 # Requirements have to be pulled and installed here, otherwise caching won't work
 COPY ./requirements /requirements
 

--- a/compose/django/Dockerfile-dev
+++ b/compose/django/Dockerfile-dev
@@ -2,6 +2,12 @@ FROM python:3.5
 
 ENV PYTHONUNBUFFERED 1
 
+
+RUN apt-get install -y ca-certificates wget \
+    && wget https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem -P /usr/local/share/ca-certificates/ \
+    && mv /usr/local/share/ca-certificates/rds-ca-2015-root.pem /usr/local/share/ca-certificates/rds-ca-2015-root.crt \
+    && update-ca-certificates
+
 # Requirements have to be pulled and installed here, otherwise caching won't work
 COPY ./requirements /requirements
 RUN pip install -r /requirements/local.txt

--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -19,20 +19,14 @@ if [ -z "$POSTGRES_DB" ]; then
     export POSTGRES_DB=$POSTGRES_USER
 fi
 
-apt-get install -y ca-certificates wget
-wget https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem -P /usr/local/share/ca-certificates/
-update-ca-certificates
-
-
 export DATABASE_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:5432/$POSTGRES_DB
-
 
 function postgres_ready(){
 python << END
 import sys
 import psycopg2
 if "$POSTGRES_USE_AWS_SSL".lower() == 'true':
-    kwargs = {"sslrootcert": "rds-ca-2015-root.pem", "sslmode": "require"}
+    kwargs = {"sslrootcert": "rds-ca-2015-root.crt", "sslmode": "require"}
 else:
     kwargs = {}
 try:

--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -16,7 +16,7 @@ if [ -z "$POSTGRES_HOST" ]; then
     export POSTGRES_HOST=postgres
 fi
 if [ -z "$POSTGRES_DB" ]; then
-    export POSTGRES_DB=postgres
+    export POSTGRES_DB=$POSTGRES_USER
 fi
 
 apt-get install -y ca-certificates wget

--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -12,16 +12,31 @@ export REDIS_URL=redis://redis:6379
 if [ -z "$POSTGRES_USER" ]; then
     export POSTGRES_USER=postgres
 fi
+if [ -z "$POSTGRES_HOST" ]; then
+    export POSTGRES_HOST=postgres
+fi
+if [ -z "$POSTGRES_DB" ]; then
+    export POSTGRES_DB=postgres
+fi
 
-export DATABASE_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres:5432/$POSTGRES_USER
+apt-get install -y ca-certificates wget
+wget https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem -P /usr/local/share/ca-certificates/
+update-ca-certificates
+
+
+export DATABASE_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:5432/$POSTGRES_DB
 
 
 function postgres_ready(){
 python << END
 import sys
 import psycopg2
+if "$POSTGRES_USE_AWS_SSL".lower() == 'true':
+    kwargs = {"sslrootcert": "rds-ca-2015-root.pem", "sslmode": "require"}
+else:
+    kwargs = {}
 try:
-    conn = psycopg2.connect(dbname="$POSTGRES_USER", user="$POSTGRES_USER", password="$POSTGRES_PASSWORD", host="postgres")
+    conn = psycopg2.connect(dbname="$POSTGRES_DB", user="$POSTGRES_USER", password="$POSTGRES_PASSWORD", host="$POSTGRES_HOST", **kwargs)
 except psycopg2.OperationalError:
     sys.exit(-1)
 sys.exit(0)

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -111,6 +111,9 @@ DATABASES = {
 }
 DATABASES['default']['ATOMIC_REQUESTS'] = True
 
+if env.bool('POSTGRES_USE_AWS_SSL', False):
+    DATABASES['default']['OPTIONS'] = {'sslrootcert': 'rds-ca-2015-root.pem', 'sslmode': 'require'}
+
 
 # GENERAL CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -112,7 +112,7 @@ DATABASES = {
 DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 if env.bool('POSTGRES_USE_AWS_SSL', False):
-    DATABASES['default']['OPTIONS'] = {'sslrootcert': 'rds-ca-2015-root.pem', 'sslmode': 'require'}
+    DATABASES['default']['OPTIONS'] = {'sslrootcert': 'rds-ca-2015-root.crt', 'sslmode': 'require'}
 
 
 # GENERAL CONFIGURATION

--- a/env.example
+++ b/env.example
@@ -1,7 +1,10 @@
 
 # PostgreSQL
+POSTGRES_HOST=postgres
+POSTGRES_DB=postgresuser
 POSTGRES_PASSWORD=mysecretpass
 POSTGRES_USER=postgresuser
+POSTGRES_USE_AWS_SSL=false
 
 # General settings
 DJANGO_ADMIN_URL=


### PR DESCRIPTION
Add env vars to allow other postgres hosts. If nothing in the .envs on our servers changes, this change should have no effect. But, if in the .env we specify AWS RDS Postgres as the host, that  will be used.

My migration strategy is:
1. docker-compose down
2. Migrate the content from the in-container postgres to the remote AWS RDS in our new AWS account. I tried this out using pg_dump and psql commands, and it seemed to go well.
3. Set the .env to point to the remote AWS RDS.
4. docker-composer up

I would do those steps first on the development server to see how it goes, then do the same in prod after we release.

I also added the ability to enable SSL for our connection to the remote AWS RDS. If needed in the future, we could add more flexibility for what certificate to use, but I didn't want to make the .env too complicated for now. Once our EC2s are also running in the new account, SSL won't be needed, since it will all be in the same VPC and I can disable external access to the RDS.