### PR TITLE
Correct deployment group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ deploy:
       secure: UUvcBDt3HDSzlCvQwuPvUh+2YFgiq0ou+fYqWWebcmEC8rEPJo4CTv4OkmqH7TejOTVepQsPI+grbdUG3ktRKJ9qHIi7Z2s3R7qDvXcb8KDoLdhYHoHVq0i/DQthNrlPuYJCaIU0WVs1wjcGbPK3xw5deP7yQIDvaeQa1ZCTBg1JbI08rtQ0iiZgklOKd1amSayneu7k48BxKbkUSJrpEJXy5y0eJKBfV5hhzuYeksguG9sZH0UuuUochXHzWJMyR0nQtUPLdnrIWGHJGYvYOTt05L/9cre6uc8Va/iJKm1ui2/nDgJNbTgE8WcfLjT4uCrTbQEBv/LSZ5X3inDVctAq3lrMBuyJOsjOlZ5ZidQ7MGWKo4tPTlxIILOsk/IhDn7YTzN1rzb5hOGJLWjid4EfRApm0pJW6A9TvuaO7zYBokSoGe47hMKVuOSfpCw3xQV2QScy6Ptf4ErSmjZ+9bMLA6Cn+Aav33upn7xPef0g/g1J31lYjP0W1YUU+hLiwACidJ/Ykdp8ksHW818D/qiePsfTgq+Q7JAOUkrTeb/Ad/3fJIcTFOaGnWAxtgtbxpKRUWARiwI8oxSaXIOx5dS4LV59t2zsiZ0Wvp+o7ql3BoD8HyLAEY1BF7a6QPLmUoEjJUeOo0qyN9GC7jEQy4Jfb4sbNTokc9MCe+Szq0U=
     revision_type: github
     application: beta-rovercode-web
-    deployment_group: rovercode-web
+    deployment_group: beta-rovercode-web
     on:
       repo: rovercode/rovercode-web
       branch: development


### PR DESCRIPTION
The applications and deployment groups should have the same names. I had a copy-paste error on the new beta deployment.