### PR TITLE
Correct the new beta deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ language: python
 python:
 - '3.5'
 deploy:
-  matrix:
   - provider: codedeploy
     access_key_id: AKIAIZTZIW2KWAYZ6MUQ
     secret_access_key:
@@ -45,10 +44,11 @@ deploy:
       repo: rovercode/rovercode-web
       branch: master
   - provider: codedeploy
-    access_key_id: AKIAIGOTYWNVPHOL5OGQ
+    access_key_id: AKIAIGTJF2ZRMY5BAAKQ
     secret_access_key:
-      secure: UUvcBDt3HDSzlCvQwuPvUh+2YFgiq0ou+fYqWWebcmEC8rEPJo4CTv4OkmqH7TejOTVepQsPI+grbdUG3ktRKJ9qHIi7Z2s3R7qDvXcb8KDoLdhYHoHVq0i/DQthNrlPuYJCaIU0WVs1wjcGbPK3xw5deP7yQIDvaeQa1ZCTBg1JbI08rtQ0iiZgklOKd1amSayneu7k48BxKbkUSJrpEJXy5y0eJKBfV5hhzuYeksguG9sZH0UuuUochXHzWJMyR0nQtUPLdnrIWGHJGYvYOTt05L/9cre6uc8Va/iJKm1ui2/nDgJNbTgE8WcfLjT4uCrTbQEBv/LSZ5X3inDVctAq3lrMBuyJOsjOlZ5ZidQ7MGWKo4tPTlxIILOsk/IhDn7YTzN1rzb5hOGJLWjid4EfRApm0pJW6A9TvuaO7zYBokSoGe47hMKVuOSfpCw3xQV2QScy6Ptf4ErSmjZ+9bMLA6Cn+Aav33upn7xPef0g/g1J31lYjP0W1YUU+hLiwACidJ/Ykdp8ksHW818D/qiePsfTgq+Q7JAOUkrTeb/Ad/3fJIcTFOaGnWAxtgtbxpKRUWARiwI8oxSaXIOx5dS4LV59t2zsiZ0Wvp+o7ql3BoD8HyLAEY1BF7a6QPLmUoEjJUeOo0qyN9GC7jEQy4Jfb4sbNTokc9MCe+Szq0U=
+      secure: uD0Z3WxSFyHp32ivolxlM3QZ8jcp5E7unQvwFNuFSOoQ1KlHyXIEtnat3HZvwUhTw5cdQcO6KYd6/cSUBfy/yRpchXE4Mv6TBXcrvbArSQHAGP/s2lbV4DjJp0xx2n65vvzD0JaxcnMUuQbIBO/4aUwRmJj/Aarri0OWnT4UPAO/B/oi5b/IjzKKz4MUDh6cgXxGsI5sgQnkRQPszPmvos5kIQ1Eoun9Vg88JPJNl/04OhEJlh2aDKBHk5yfrQN+d48OZsVMiSBw6ioIRHa2F6EeaB+6Zomro6AFY3Zgwkx64m93C6B6lw6j6h2szCGMP4rSnUmcgiAleXiOw2iptXbGSx2+hAhk0ohIntwuYtxUtAZEewTfqzMAJMDOy2jMWkT7xxGQ1ihypMtLWfqJqD3d8RHt2cKizOjICSG/w5plxybbHI38ONuj9Qo29Zrw0Jss0ufmCu1zqr2LgqN3yFVIxd1etsB8CDaYfHOTNyGBWzRfiupJ6xe9KvNht4p71Xt2chAbSNjhv7Ow2Pg1IYerowlzo2j7CXfNZ2s0iTOmsGPteKkHn1yMXa47ISQSGkVPWacgm3ZJ2RCWJuP4juioUz8wpKXcqXfrA4QRCeQoE8Bpu4tg9otJEab5Z3CkQ+laFfiKnhfJ9n2GBuDafs+Yz7DzCIoLorTnWTgnUcA=
     revision_type: github
+    region: us-east-2
     application: beta-rovercode-web
     deployment_group: beta-rovercode-web
     on:


### PR DESCRIPTION
To get the new beta deploy to work, I did three things:
* Regenerate the encrypted aws secret. The only reliable way I've been able to do it is to use `travis setup codedeploy` wizard, copy the deploy block it makes (it will have wiped out your other deploy blocks), git checkout to get your original deploy blocks back, then paste in your new one.
* Get rid of the `matrix:`. I'm not 100% that it needed to be taken out, but I believe my experiments that included it did not work.
* Add region. It defaults to us-east-1, which worked for our old account, but the new one needs us-east-2.