### PR TITLE
Oauth client_id filter for rover API

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from django.db.utils import IntegrityError
 from urllib.parse import urlencode
 
+from oauth2_provider.models import Application
 from mission_control.models import Rover, BlockDiagram
 
 
@@ -88,6 +89,39 @@ class TestRoverViewSet(BaseAuthenticatedTestCase):
         )
         response = self.get(
             reverse('api:v1:rover-list') + '?name=' + rover2.name)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, len(response.json()))
+        self.assertEqual(response.json()[0]['name'], 'rover2')
+        self.assertEqual(response.json()[0]['owner'], self.admin.id)
+        self.assertEqual(response.json()[0]['local_ip'], '8.8.8.8')
+
+    def test_rover_client_id_filter(self):
+        """Test the rover view filters correctly on oauth application client id."""
+        self.client.login(username='administrator', password='password')
+        Rover.objects.create(
+            name='rover',
+            owner=self.admin,
+            local_ip='8.8.8.8',
+            oauth_application = Application.objects.create(
+                user=self.admin,
+                authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+                client_type=Application.CLIENT_CONFIDENTIAL,
+                name='rover'
+            )
+        )
+        rover2 = Rover.objects.create(
+            name='rover2',
+            owner=self.admin,
+            local_ip='8.8.8.8',
+            oauth_application = Application.objects.create(
+                user=self.admin,
+                authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+                client_type=Application.CLIENT_CONFIDENTIAL,
+                name='rover2'
+            )
+        )
+        response = self.get(
+            reverse('api:v1:rover-list') + '?oauth_application__client_id=' + rover2.oauth_application.client_id)
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.json()))
         self.assertEqual(response.json()[0]['name'], 'rover2')

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -121,7 +121,7 @@ class TestRoverViewSet(BaseAuthenticatedTestCase):
             )
         )
         response = self.get(
-            reverse('api:v1:rover-list') + '?oauth_application__client_id=' + rover2.oauth_application.client_id)
+            reverse('api:v1:rover-list') + '?client_id=' + rover2.oauth_application.client_id)
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.json()))
         self.assertEqual(response.json()[0]['name'], 'rover2')

--- a/api/views.py
+++ b/api/views.py
@@ -2,6 +2,7 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets, permissions, serializers
 
+from mission_control.filters import RoverFilter
 from mission_control.models import Rover, BlockDiagram
 from mission_control.serializers import RoverSerializer, BlockDiagramSerializer
 
@@ -12,7 +13,7 @@ class RoverViewSet(viewsets.ModelViewSet):
     serializer_class = RoverSerializer
     permission_classes = (permissions.IsAuthenticated, )
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('name', 'oauth_application__client_id')
+    filter_class = RoverFilter
 
     def get_queryset(self):
         """The list of rovers for the user."""

--- a/api/views.py
+++ b/api/views.py
@@ -9,8 +9,6 @@ from mission_control.serializers import RoverSerializer, BlockDiagramSerializer
 class RoverViewSet(viewsets.ModelViewSet):
     """API endpoint that allows rovers to be viewed or edited."""
 
-    client_id = serializers.CharField(source='oauth_application.client_id',
-                                      read_only=True)
     serializer_class = RoverSerializer
     permission_classes = (permissions.IsAuthenticated, )
     filter_backends = (DjangoFilterBackend,)

--- a/api/views.py
+++ b/api/views.py
@@ -9,10 +9,12 @@ from mission_control.serializers import RoverSerializer, BlockDiagramSerializer
 class RoverViewSet(viewsets.ModelViewSet):
     """API endpoint that allows rovers to be viewed or edited."""
 
+    client_id = serializers.CharField(source='oauth_application.client_id',
+                                      read_only=True)
     serializer_class = RoverSerializer
     permission_classes = (permissions.IsAuthenticated, )
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('name',)
+    filter_fields = ('name', 'oauth_application__client_id')
 
     def get_queryset(self):
         """The list of rovers for the user."""

--- a/mission_control/filters.py
+++ b/mission_control/filters.py
@@ -1,0 +1,17 @@
+"""Mission Control filters."""
+from django_filters.rest_framework import CharFilter
+from django_filters.rest_framework import FilterSet
+
+from .models import Rover
+
+
+class RoverFilter(FilterSet):
+    """Filterset for the Rover model."""
+
+    client_id = CharFilter(name='oauth_application__client_id')
+
+    class Meta:
+        """Meta class."""
+
+        model = Rover
+        fields = ['name', 'client_id']

--- a/mission_control/static/js/cred-download.js
+++ b/mission_control/static/js/cred-download.js
@@ -1,6 +1,6 @@
 $("#download-env").click(function() {
     if ('Blob' in window) {
-        var textToSave = "client_id:"+clientId+"\nclientSecret:"+clientSecret+"\n";
+        var textToSave = "CLIENT_ID="+clientId+"\nCLIENT_SECRET="+clientSecret+"\n";
         var textToSaveAsBlob = new Blob([textToSave], {type:"text/plain"});
         var textToSaveAsURL = window.URL.createObjectURL(textToSaveAsBlob);
         var fileNameToSaveAs = "rovercode_"+name+".env";


### PR DESCRIPTION
Fixes #130.

The rover needs to be able to find itself by oauth client id, so this adds a filter for that to the rover REST API.

Also, the formatting of the credentials file download was wacky, so I fixed that.