### PR TITLE
API documentation with Swagger UI

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from django.conf.urls import include, url
 from . import views
 from rest_framework import routers
+from rest_framework_swagger.views import get_swagger_view
 
 router = routers.DefaultRouter()
 router.register(r'rovers', views.RoverViewSet, base_name='rover')
@@ -12,5 +13,6 @@ router.register(r'block-diagrams', views.BlockDiagramViewSet)
 
 
 urlpatterns = [
+    url(r'^$', get_swagger_view(title='rovercode API')),
     url(r'^v1/', include(router.urls, namespace='v1')),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -8,7 +8,26 @@ from mission_control.serializers import RoverSerializer, BlockDiagramSerializer
 
 
 class RoverViewSet(viewsets.ModelViewSet):
-    """API endpoint that allows rovers to be viewed or edited."""
+    """API endpoint that allows rovers to be viewed or edited.
+
+    retrieve:
+        Return a rover instance.
+
+    list:
+        Return all rovers.
+
+    create:
+        Register a new rover.
+
+    delete:
+        Remove an existing rover.
+
+    partial_update:
+        Update one or more fields on an existing rover.
+
+    update:
+        Update a rover.
+    """
 
     serializer_class = RoverSerializer
     permission_classes = (permissions.IsAuthenticated, )
@@ -26,7 +45,26 @@ class RoverViewSet(viewsets.ModelViewSet):
 
 
 class BlockDiagramViewSet(viewsets.ModelViewSet):
-    """API endpoint that allows block diagrams to be viewed or edited."""
+    """API endpoint that allows block diagrams to be viewed or edited.
+
+    retrieve:
+        Return a block diagram instance.
+
+    list:
+        Return all block diagrams.
+
+    create:
+        Create a new block diagram.
+
+    delete:
+        Remove an existing block diagram.
+
+    partial_update:
+        Update one or more fields on an existing block diagram.
+
+    update:
+        Update a block diagram.
+    """
 
     queryset = BlockDiagram.objects.all()
     serializer_class = BlockDiagramSerializer

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -42,6 +42,7 @@ THIRD_PARTY_APPS = (
     'allauth.socialaccount',  # registration
     'rest_framework',
     'oauth2_provider',
+    'rest_framework_swagger',
 )
 
 # Apps specific for this project go here.
@@ -256,6 +257,7 @@ SOCIALACCOUNT_ADAPTER = 'rovercode_web.users.adapters.SocialAccountAdapter'
 AUTH_USER_MODEL = 'users.User'
 LOGIN_REDIRECT_URL = 'users:redirect'
 LOGIN_URL = 'account_login'
+LOGOUT_URL = 'account_logout'
 
 # SLUGLIFIER
 AUTOSLUG_SLUGIFY_FUNCTION = 'slugify.slugify'
@@ -280,6 +282,9 @@ OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 # REST FRAMEWORK CONFIGURATION
 # ------------------------------------------------------------------------------
 REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.SessionAuthentication',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,6 +46,7 @@ redis>=2.10.5
 
 # Your custom requirements go here
 djangorestframework~=3.5.3
+django-rest-swagger==2.2.0
 django-filter==1.0.1
 pylint==1.6.5
 pylint-django==0.8.0

--- a/rovercode_web/blog/views.py
+++ b/rovercode_web/blog/views.py
@@ -51,7 +51,26 @@ def post_detail(request, slug):
 
 
 class PostViewSet(viewsets.ModelViewSet):
-    """API endpoint that allows posts to be viewed or edited."""
+    """API endpoint that allows posts to be viewed or edited.
+
+    retrieve:
+        Return a blog post instance.
+
+    list:
+        Return all blog posts.
+
+    create:
+        Create a new blog post.
+
+    delete:
+        Remove an existing blog post.
+
+    partial_update:
+        Update one or more fields on an existing blog post.
+
+    update:
+        Update a blog post.
+    """
 
     serializer_class = PostSerializer
     queryset = Post.objects.all()


### PR DESCRIPTION
Changes from the Django REST Framework browsable UI to [Swagger UI](https://swagger.io/swagger-ui/). Swagger is accessible at `/api/`. Endpoints or operations that the user is not permitted to use are hidden.

![image](https://user-images.githubusercontent.com/1184314/39790875-61d5cc9a-5306-11e8-843c-6f2ae76771dc.png)
![image](https://user-images.githubusercontent.com/1184314/39790884-6f6c9082-5306-11e8-9a7f-1b1f8d35f527.png)
![image](https://user-images.githubusercontent.com/1184314/39790948-ce71eeb0-5306-11e8-8f71-b0fa74ddf474.png)
