### PR TITLE
Add social auth for account sign in

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -40,6 +40,8 @@ THIRD_PARTY_APPS = (
     'allauth',  # registration
     'allauth.account',  # registration
     'allauth.socialaccount',  # registration
+    'allauth.socialaccount.providers.github',
+    'allauth.socialaccount.providers.google',
     'rest_framework',
     'oauth2_provider',
     'rest_framework_swagger',
@@ -172,6 +174,7 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
                 # Your stuff: custom template context processors go here
+                'django.template.context_processors.request',
             ],
         },
     },
@@ -290,4 +293,19 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ),
+}
+
+# SOCIAL ACCOUNT CONFIGURATION
+# ------------------------------------------------------------------------------
+SOCIALACCOUNT_QUERY_EMAIL = True
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'SCOPE': [
+            'profile',
+            'email',
+        ],
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+        }
+    }
 }

--- a/rovercode_web/templates/account/login.html
+++ b/rovercode_web/templates/account/login.html
@@ -20,7 +20,7 @@
 {% get_providers as socialaccount_providers %}
 
 {% if socialaccount_providers %}
-<p>Please sign in with one of your existing third party accounts.</p>
+<p>You can sign up / sign in with one of your existing third-party accounts.</p>
 
 <div class="socialaccount_ballot">
 
@@ -52,15 +52,14 @@
 </div>
 
 {% include "socialaccount/snippets/login_extra.html" %}
-
-<p>{% blocktrans with site.name as site_name %}Or, <a href="{{ signup_url }}">sign up</a>
-for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
+<p>{% blocktrans %}Don't have any of those accounts? <a href="{{ signup_url }}">Create a rovercode account.</a>{% endblocktrans %}</p>
 
 {% else %}
 <p>{% blocktrans %}If you have not created an account yet, then please
 <a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
 {% endif %}
 
+<p>{% blocktrans %}Already have a rovercode account? Sign in here:{% endblocktrans %}</p>
 <form class="login" method="POST" action="{% url 'account_login' %}">
   {% csrf_token %}
   {{ form|crispy }}

--- a/rovercode_web/templates/account/login.html
+++ b/rovercode_web/templates/account/login.html
@@ -1,8 +1,15 @@
 {% extends "account/base.html" %}
 
 {% load i18n %}
+{% load staticfiles i18n %}
 {% load account socialaccount %}
 {% load crispy_forms_tags %}
+
+{% block css %}
+{{ block.super}}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-social/5.1.1/bootstrap-social.min.css" integrity="sha256-rFMLRbqAytD9ic/37Rnzr2Ycy/RlpxE5QH52h7VoIZo=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+{% endblock %}
 
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 
@@ -13,21 +20,41 @@
 {% get_providers as socialaccount_providers %}
 
 {% if socialaccount_providers %}
-<p>{% blocktrans with site.name as site_name %}Please sign in with one
-of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
-for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
+<p>Please sign in with one of your existing third party accounts.</p>
 
 <div class="socialaccount_ballot">
 
-  <ul class="socialaccount_providers">
-    {% include "socialaccount/snippets/provider_list.html" with process="login" %}
-  </ul>
+  <ul class="socialaccount_providers list-inline">
+    {% load socialaccount %}
 
-  <div class="login-or">{% trans 'or' %}</div>
+    {% get_providers as socialaccount_providers %}
+
+    {% for provider in socialaccount_providers %}
+    {% if provider.id == "openid" %}
+    {% for brand in provider.get_brands %}
+    <li class="list-inline-item">
+      <a title="{{brand.name}}"
+         class="socialaccount_provider {{provider.id}} {{brand.id}}"
+         href="{% provider_login_url provider.id openid=brand.openid_url process=process %}"
+         ></a>
+    </li>
+    {% endfor %}
+    {% endif %}
+    <li class="list-inline-item">
+      <a title="{{provider.name}}" class="socialaccount_provider btn btn-block btn-social btn-{% filter lower %}{{provider.name}}{% endfilter %}"
+         href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+        <span class="fa fa-{% filter lower %}{{provider.name}}{% endfilter %}"></span> Sign in with {{provider.name}}
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
 
 </div>
 
 {% include "socialaccount/snippets/login_extra.html" %}
+
+<p>{% blocktrans with site.name as site_name %}Or, <a href="{{ signup_url }}">sign up</a>
+for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
 
 {% else %}
 <p>{% blocktrans %}If you have not created an account yet, then please

--- a/rovercode_web/templates/base.html
+++ b/rovercode_web/templates/base.html
@@ -68,9 +68,6 @@
                 </li>
               {% else %}
                 <li class="nav-item">
-                  <a id="sign-up-link" class="nav-link" href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a>
-                </li>
-                <li class="nav-item">
                   <a id="log-in-link" class="nav-link" href="{% url 'account_login' %}">{% trans "Sign In" %}</a>
                 </li>
               {% endif %}


### PR DESCRIPTION
Add buttons to use `GitHub` and `Google` for authentication. This won't "just work" as we'll need to register applications in the `rovercode` `Google` and `GitHub` organizations. Then, use the Django admin to enter the credentials in the deployed application. `Twitter` and `Facebook` can be added fairly easily as well.

![image](https://user-images.githubusercontent.com/1184314/40211207-4b50ea00-5a17-11e8-9090-c30e5fa2d1e1.png)
