### PR TITLE
Use https for allauth links for production

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -215,3 +215,7 @@ ADMIN_URL = env('DJANGO_ADMIN_URL')
 
 # Your production stuff: Below this line define 3rd party library settings
 # ------------------------------------------------------------------------------
+
+# SOCIAL ACCOUNT CONFIGURATION
+# ------------------------------------------------------------------------------
+ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'


### PR DESCRIPTION
Only set for `production` so that local testing will still work with `http`