### PR TITLE
Fix nginx startup script for alpine system

### DIFF
--- a/compose/nginx/start.sh
+++ b/compose/nginx/start.sh
@@ -56,7 +56,7 @@ sed -i "s/___NAMESERVER___/$NAMESERVER/g" /etc/nginx/nginx-secure.conf
 
 
 #go!
-kill $(ps aux | grep 'nginx' | grep -v 'grep' | awk '{print $2}')
+kill $(ps aux | grep 'nginx' | grep -v 'grep' | awk '{print $1}')
 cp /etc/nginx/nginx-secure.conf /etc/nginx/nginx.conf
 
 nginx -g 'daemon off;'


### PR DESCRIPTION
The `ps` command returns information in different columns so the `start.sh` script for `nginx` was incorrectly trying to kill the wrong thing and exiting. This fixes the issue and it currently is running on `beta` with this applied manually.