### PR TITLE
Remove multiple travis scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
 script:
 - py.test --cov-report=
 - prospector
-script:
 - pushd docs
 - make html
 - popd


### PR DESCRIPTION
Prospector was failing to run because there were multiple script sections in the travis.yaml.
