### PR TITLE
Downgrade DRF to fix swagger UI issue

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,17 +1,12 @@
 [[source]]
-
 verify_ssl = true
 name = "pypi"
 url = "https://pypi.org/simple"
 
-
 [requires]
-
 python_version = "3.6"
 
-
 [dev-packages]
-
 pylint = "==1.7.6"
 pylint-django = "==0.7.2"
 prospector = "==0.12.10"
@@ -28,9 +23,7 @@ Sphinx = "==1.7.5"
 Werkzeug = "==0.14.1"
 factory_boy = "==2.11.1"
 
-
 [packages]
-
 django-environ = "==0.4.4"
 whitenoise = "==3.3.1"
 django-braces = "==1.13.0"
@@ -42,7 +35,7 @@ awesome-slugify = "==1.6.5"
 pytz = "==2018.4"
 django-redis = "==4.9.0"
 redis = "==2.10.6"
-djangorestframework = "==3.8.2"
+djangorestframework = "==3.5.4"
 django-rest-swagger = "==2.2.0"
 django-filter = "==1.1.0"
 django-oauth-toolkit = "==1.1.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "84c739804fe690e78778b671d65f9d6cbd392540b74c679f11ae6e69b8fdebed"
+            "sha256": "5687ef333c7f84b87b66810254b2935e9f4b92a55b4687a0ba44cdde0803472d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -163,11 +163,11 @@
         },
         "djangorestframework": {
             "hashes": [
-                "sha256:b6714c3e4b0f8d524f193c91ecf5f5450092c2145439ac2769711f7eba89a9d9",
-                "sha256:c375e4f95a3a64fccac412e36fb42ba36881e52313ec021ef410b40f67cddca4"
+                "sha256:110afa12784ceadfb50808882689302d266785b51e3d13286744333ff6d78e60",
+                "sha256:f995a35ae22f354d2a9a42ee6d2c059c101f826b1485ed46781677895ad25ee5"
             ],
             "index": "pypi",
-            "version": "==3.8.2"
+            "version": "==3.5.4"
         },
         "gevent": {
             "hashes": [


### PR DESCRIPTION
Newer versions of DRF cause swagger UI to use `http` requests when using
`try it out` which breaks on a production deploy using `https`. There is a
selection for `schemes` but it only has `http` as a choice. It's not clear
what is causing this issue and it is easier for now to just go back to the
working version.

Also, newer versions of DRF have built-in interactive API documentation support that we might want to switch to: http://www.django-rest-framework.org/topics/3.6-announcement/

It's currently in this broken condition on https://beta.rovercode.com/api/

![image](https://user-images.githubusercontent.com/1184314/40869454-51e146ac-65e9-11e8-920f-c23ff77f18a0.png)
![image](https://user-images.githubusercontent.com/1184314/40869455-5b93fb9a-65e9-11e8-98d7-085dcce1b56b.png)
