### PR TITLE
Hide knowledge of invalid email addresses in password reset

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -254,6 +254,9 @@ ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_ALLOW_REGISTRATION = env.bool('DJANGO_ACCOUNT_ALLOW_REGISTRATION', True)
 ACCOUNT_ADAPTER = 'rovercode_web.users.adapters.AccountAdapter'
 SOCIALACCOUNT_ADAPTER = 'rovercode_web.users.adapters.SocialAccountAdapter'
+ACCOUNT_FORMS = {
+    'reset_password': 'rovercode_web.users.forms.SilentResetPasswordForm',
+}
 
 # Custom user app defaults
 # Select the correct user model

--- a/rovercode_web/users/forms.py
+++ b/rovercode_web/users/forms.py
@@ -1,0 +1,16 @@
+"""Users forms."""
+from allauth.account.adapter import get_adapter
+from allauth.account.forms import ResetPasswordForm
+from allauth.account.utils import filter_users_by_email
+
+
+class SilentResetPasswordForm(ResetPasswordForm):
+    """Does not show an error if the email does not exist in the system."""
+
+    def clean_email(self):
+        """Clean email field."""
+        email = self.cleaned_data["email"]
+        email = get_adapter().clean_email(email)
+        self.users = filter_users_by_email(email)
+
+        return self.cleaned_data["email"]

--- a/rovercode_web/users/tests/test_forms.py
+++ b/rovercode_web/users/tests/test_forms.py
@@ -1,0 +1,17 @@
+"""Form tests."""
+from test_plus.test import TestCase
+
+from ..forms import SilentResetPasswordForm
+
+
+class TestForms(TestCase):
+    """Tests the forms."""
+
+    def test_silent_reset_password_form(self):
+        """Tests the silent reset password form."""
+        data = {
+            'email': 'notauser@example.com'
+        }
+        form = SilentResetPasswordForm(data)
+
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
Closes #190 

Any email address entered now shows:
![image](https://user-images.githubusercontent.com/1184314/40948917-3eb8d066-6839-11e8-9e23-59710aed5e4d.png)

Even if the email is not associated with any user in the system. The email is still sent if the user is in the system.

This is the original form: https://github.com/pennersr/django-allauth/blob/master/allauth/account/forms.py#L499