### PR TITLE
Password reset

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -29,6 +29,9 @@ urlpatterns = [
     url(r'^api-auth/',
         include('rest_framework.urls', namespace='rest_framework')),
     url(r'^jwt/', include('authorize.urls', namespace='jwt')),
+    url(r'^jwt/auth/password-reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',  # noqa
+        TemplateView.as_view(template_name="password_reset_confirm.html"),
+        name='password_reset_confirm'),
     url(r'^docs/', include_docs_urls(
         title='rovercode API',
         description='API for the rovercode web service.',

--- a/rovercode_web/templates/registration/password_reset_email.html
+++ b/rovercode_web/templates/registration/password_reset_email.html
@@ -1,0 +1,14 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+
+{% trans "Please go to the following page and choose a new password:" %}
+{% block reset_link %}
+{{ protocol }}://{{ domain }}/accounts/reset/callback/{{ uid }}/{{ token }}
+{% endblock %}
+{% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
+
+{% trans "Thanks for using our site!" %}
+
+{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
+
+{% endautoescape %}


### PR DESCRIPTION
The password reset view needs `password_reset_confirm` to be defined to generate the proper `uid` and `token`. For the new frontend, the link in the email needs to be changed to point to the frontend route. For the email link to work in development, the `domain` for the `Site` needs to be changed to `localhost:8080` to hit the frontend.
From a Django shell:
```
site = Site.objects.first()
site.domain = 'localhost:8080'
site.save()
```
The email can be seen in `mailhog` on `http://localhost:8025`.
For the production case, this won't be an issue since the backend and frontend will be on the same domain.