### PR TITLE
Move login callback to be consistent with other account routes

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -329,5 +329,5 @@ REST_USE_JWT = True
 
 SOCIAL_CALLBACK_URL = env(
     'SOCIAL_CALLBACK_URL',
-    default='http://localhost:8080/login/{service}/callback/'
+    default='http://localhost:8080/accounts/login/callback/{service}'
 )


### PR DESCRIPTION
The login callback route hadn't been moved to `/accounts` like the other routes