### PR TITLE
Fix Daphne failure

### DIFF
--- a/config/asgi.py
+++ b/config/asgi.py
@@ -20,7 +20,3 @@ application = ProtocolTypeRouter({
         )
     ),
 })
-
-if os.environ.get('DJANGO_SETTINGS_MODULE') == 'config.settings.production':
-    from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
-    application = Sentry(application)


### PR DESCRIPTION
Trying to init Sentry on the application was causing Daphne to give `500 HTTP Processing Errors` to all requests.

[Here's the post that tipped me off](https://github.com/getsentry/raven-python/issues/1264#issuecomment-415406734).

I tried out this fix on the beta EC2, and it's serving everything fine now.

Maybe one day down the line we can figure out how to init Sentry on an ASGI application.