### PR TITLE
Add missing line continuation

### DIFF
--- a/compose/django/Dockerfile
+++ b/compose/django/Dockerfile
@@ -27,7 +27,7 @@ RUN sed -i 's/\r//' /entrypoint.sh \
     && chmod +x /entrypoint.sh \
     && chown django /entrypoint.sh \
     && chmod +x /gunicorn.sh \
-    && chown django /gunicorn.sh
+    && chown django /gunicorn.sh \
     && chmod +x /daphne.sh \
     && chown django /daphne.sh
 


### PR DESCRIPTION
I was missing a line-continuation `\` in the dockerfile. 
I fixed that manually on the beta EC2, and both the https and wss routes work!