### PR TITLE
Add OAuth2 support to realtime

### DIFF
--- a/config/asgi.py
+++ b/config/asgi.py
@@ -13,12 +13,13 @@ from channels.sessions import SessionMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 import realtime.routing
 from middleware.channels_jwt_middleware import ChannelsJwtMiddleware
+from middleware.channels_oauth2_middleware import ChannelsOAuth2Middleware
 
 application = ProtocolTypeRouter({
     # (http->django views is added by default)
-    'websocket': SessionMiddlewareStack(ChannelsJwtMiddleware(AuthMiddlewareStack(
+    'websocket': SessionMiddlewareStack(ChannelsJwtMiddleware(ChannelsOAuth2Middleware(AuthMiddlewareStack(
         URLRouter(
             realtime.routing.websocket_urlpatterns
         )
-    ))),
+    )))),
 })

--- a/middleware/channels_jwt_middleware.py
+++ b/middleware/channels_jwt_middleware.py
@@ -37,6 +37,10 @@ class ChannelsJwtMiddleware:
 
     def __call__(self, scope):
         """Call the middleware."""
+        if scope.get('user') and scope['user'] != AnonymousUser:
+            # We already have an authenticated user
+            return self.inner(scope)
+
         if "method" not in scope:
             scope['method'] = "FAKE"
 

--- a/middleware/channels_oauth2_middleware.py
+++ b/middleware/channels_oauth2_middleware.py
@@ -1,0 +1,67 @@
+"""OAuth2 middleware for Django Channels."""
+from django.contrib.auth.models import AnonymousUser
+
+from channels.http import AsgiRequest
+from oauth2_provider.oauth2_backends import get_oauthlib_core
+
+
+class ChannelsOAuth2Middleware:
+    """
+    OAuth2 middleware class for Channels.
+
+    Credit:
+    https://gist.github.com/stuartaccent/34852c8ccd5828bb2cc81dddb68e6538
+
+    Works in the same way as
+    `oauth2_provider.contrib.rest_framework.OAuth2Authentication`
+    but for django channels 2. Passes the scope into an AsgiRequest
+    header, and then passes it onto oauth2_provider to validate.
+    Usage:
+    application = ProtocolTypeRouter({
+        ...
+        "websocket": OAuth2Middleware(
+            URLRouter([
+                ...
+            ]),
+        ),
+    })
+    Consumer:
+    class MyConsumer(AsyncJsonWebsocketConsumer):
+        async def connect(self):
+            if self.scope["user"].is_anonymous:
+                await self.close()
+            else:
+                await self.accept()
+    """
+
+    def __init__(self, inner):
+        """Init the middleware."""
+        self.inner = inner
+
+    def __call__(self, scope):
+        """Call the middleware."""
+        def authenticate(request):
+            """
+            Authenticate the request.
+
+            Returns a tuple containing the user and their access token.
+            If it's not valid then AnonymousUser is returned.
+            """
+            oauthlib_core = get_oauthlib_core()
+            valid, r = oauthlib_core.verify_request(request, scopes=[])
+            if valid:
+                return r.user, r.access_token
+            return AnonymousUser, None
+
+        if "method" not in scope:
+            scope['method'] = "FAKE"
+
+        request = AsgiRequest(scope, b"")
+
+        if request.META.get("HTTP_AUTHORIZATION"):
+            user, _ = authenticate(request)
+            scope['user'] = user
+        else:
+            scope['user'] = AnonymousUser
+
+        return self.inner(scope)

--- a/middleware/channels_oauth2_middleware.py
+++ b/middleware/channels_oauth2_middleware.py
@@ -53,6 +53,10 @@ class ChannelsOAuth2Middleware:
                 return r.user, r.access_token
             return AnonymousUser, None
 
+        if scope.get('user') and scope['user'] != AnonymousUser:
+            # We already have an authenticated user
+            return self.inner(scope)
+
         if "method" not in scope:
             scope['method'] = "FAKE"
 

--- a/middleware/tests/test_channels_jwt_middleware.py
+++ b/middleware/tests/test_channels_jwt_middleware.py
@@ -26,8 +26,18 @@ class TestChannelsJwtMiddleware(TestCase):
             inner.assert_called_once_with(scope)
             self.assertEqual("some_user", scope["user"])
 
+    def test__call__already_auth(self):
+        """Test the __call__ method if there is already an user."""
+        inner = MagicMock()
+        uut = ChannelsJwtMiddleware(inner)
+        user = self.make_user()
+        scope = {"cookies": {"auth_jwt": "foobar"}, "user": user}
+        uut.__call__(scope)
+        inner.assert_called_once_with(scope)
+        self.assertEqual(user, scope["user"])
+
     def test__call__not_auth(self):
-        """Test the __call__ method."""
+        """Test the __call__ method if the user is not authorized."""
         inner = MagicMock()
         uut = ChannelsJwtMiddleware(inner)
         scope = {"cookies": {"auth_jwt": "foobar"}}
@@ -39,7 +49,7 @@ class TestChannelsJwtMiddleware(TestCase):
             self.assertEqual(AnonymousUser, scope["user"])
 
     def test__call__no_cookie(self):
-        """Test the __call__ method."""
+        """Test the __call__ method if the needed cookie is absent."""
         inner = MagicMock()
         uut = ChannelsJwtMiddleware(inner)
         scope = {"cookies": {"auth_jwt": None}}
@@ -51,7 +61,7 @@ class TestChannelsJwtMiddleware(TestCase):
             self.assertEqual(AnonymousUser, scope["user"])
 
     def test__call__no_cookies(self):
-        """Test the __call__ method."""
+        """Test the __call__ method if there are no cookies at all."""
         inner = MagicMock()
         uut = ChannelsJwtMiddleware(inner)
         scope = {}

--- a/middleware/tests/test_channels_oauth2_middleware.py
+++ b/middleware/tests/test_channels_oauth2_middleware.py
@@ -1,0 +1,60 @@
+"""Channels OAuth2 Middleware test models."""
+from unittest.mock import MagicMock, patch
+from django.contrib.auth.models import AnonymousUser
+from test_plus.test import TestCase
+
+
+from middleware.channels_oauth2_middleware import ChannelsOAuth2Middleware
+
+
+class TestChannelsOauth2Middleware(TestCase):
+    """Test Channels OAuth2 middleware functions."""
+
+    def test__init__(self):
+        """Test the inner initialization."""
+        uut = ChannelsOAuth2Middleware("foobar")
+        self.assertEqual("foobar", uut.inner)
+
+    def test__call__(self):
+        """Test the __call__ method."""
+        inner = MagicMock()
+        uut = ChannelsOAuth2Middleware(inner)
+        scope = {"headers": [(b'authorization', b'baz')], "path": "/asdf"}
+        with patch('middleware.channels_oauth2_middleware.get_oauthlib_core') \
+                as get_oauthlib_core:
+            oauthlib_core = MagicMock()
+            mock_oauth_response = MagicMock()
+            mock_oauth_response.user = 'test_user'
+            oauthlib_core.verify_request.return_value = \
+                (True, mock_oauth_response)
+            get_oauthlib_core.return_value = oauthlib_core
+
+            uut.__call__(scope)
+            inner.assert_called_once_with(scope)
+            self.assertEqual("test_user", scope["user"])
+
+    def test__call__not_auth(self):
+        """Test the __call__ method when the token is not for a valid user."""
+        inner = MagicMock()
+        uut = ChannelsOAuth2Middleware(inner)
+        scope = {"headers": [(b'authorization', b'baz')], "path": "/asdf"}
+        with patch('middleware.channels_oauth2_middleware.get_oauthlib_core') \
+                as get_oauthlib_core:
+            oauthlib_core = MagicMock()
+            mock_oauth_response = MagicMock()
+            mock_oauth_response.user = 'test_user'
+            oauthlib_core.verify_request.return_value = (False, None)
+            get_oauthlib_core.return_value = oauthlib_core
+
+            uut.__call__(scope)
+            inner.assert_called_once_with(scope)
+            self.assertEqual(AnonymousUser, scope["user"])
+
+    def test__call__no_token(self):
+        """Test the __call__ method when there is no token."""
+        inner = MagicMock()
+        uut = ChannelsOAuth2Middleware(inner)
+        scope = {"path": "/asdf"}
+        uut.__call__(scope)
+        inner.assert_called_once_with(scope)
+        self.assertEqual(AnonymousUser, scope["user"])

--- a/middleware/tests/test_channels_oauth2_middleware.py
+++ b/middleware/tests/test_channels_oauth2_middleware.py
@@ -33,6 +33,20 @@ class TestChannelsOauth2Middleware(TestCase):
             inner.assert_called_once_with(scope)
             self.assertEqual("test_user", scope["user"])
 
+    def test__call__already_auth(self):
+        """Test the __call__ method if there is already an user."""
+        inner = MagicMock()
+        uut = ChannelsOAuth2Middleware(inner)
+        user = self.make_user()
+        scope = {
+            "headers": [(b'authorization', b'baz')],
+            "path": "/asdf",
+            "user": user
+        }
+        uut.__call__(scope)
+        inner.assert_called_once_with(scope)
+        self.assertEqual(user, scope["user"])
+
     def test__call__not_auth(self):
         """Test the __call__ method when the token is not for a valid user."""
         inner = MagicMock()


### PR DESCRIPTION
This creates Channels middleware to validate via OAuth2 and adds it to the Realtime app.

The middleare validates tokens that appear as Bearer tokens in the Authorization header. This works great for us, because unlike browser websocket clients, the rover's Python websocket client is capable of adding custom headers to the websocket initiation request.

