### PR TITLE
Channels auth improvements

### DIFF
--- a/middleware/channels_jwt_middleware.py
+++ b/middleware/channels_jwt_middleware.py
@@ -46,14 +46,16 @@ class ChannelsJwtMiddleware:
 
         cookies = scope.get("cookies")
         if not cookies:
-            scope['user'] = AnonymousUser
             return self.inner(scope)
 
-        data = {'token': cookies.get("auth_jwt")}
+        jwt_cookie = cookies.get("auth_jwt")
+        if not jwt_cookie:
+            return self.inner(scope)
+
+        data = {'token': jwt_cookie}
         valid_data = VerifyJSONWebTokenSerializer().validate(data)
-        user = valid_data['user']
+        user = valid_data.get("user")
         if not user:
-            scope['user'] = AnonymousUser
             return self.inner(scope)
 
         scope['user'] = user

--- a/middleware/channels_oauth2_middleware.py
+++ b/middleware/channels_oauth2_middleware.py
@@ -45,13 +45,13 @@ class ChannelsOAuth2Middleware:
             Authenticate the request.
 
             Returns a tuple containing the user and their access token.
-            If it's not valid then AnonymousUser is returned.
+            If it's not valid then None is returned.
             """
             oauthlib_core = get_oauthlib_core()
             valid, r = oauthlib_core.verify_request(request, scopes=[])
             if valid:
                 return r.user, r.access_token
-            return AnonymousUser, None
+            return None, None
 
         if scope.get('user') and scope['user'] != AnonymousUser:
             # We already have an authenticated user
@@ -64,8 +64,7 @@ class ChannelsOAuth2Middleware:
 
         if request.META.get("HTTP_AUTHORIZATION"):
             user, _ = authenticate(request)
-            scope['user'] = user
-        else:
-            scope['user'] = AnonymousUser
+            if user:
+                scope['user'] = user
 
         return self.inner(scope)

--- a/middleware/tests/test_channels_jwt_middleware.py
+++ b/middleware/tests/test_channels_jwt_middleware.py
@@ -1,6 +1,5 @@
 """Channels JWT Middleware test models."""
 from unittest.mock import MagicMock, patch
-from django.contrib.auth.models import AnonymousUser
 from test_plus.test import TestCase
 
 
@@ -46,7 +45,7 @@ class TestChannelsJwtMiddleware(TestCase):
             validate.return_value = {"user": None}
             uut.__call__(scope)
             inner.assert_called_once_with(scope)
-            self.assertEqual(AnonymousUser, scope["user"])
+            self.assertFalse("user" in scope)
 
     def test__call__no_cookie(self):
         """Test the __call__ method if the needed cookie is absent."""
@@ -58,7 +57,7 @@ class TestChannelsJwtMiddleware(TestCase):
             validate.return_value = {"user": None}
             uut.__call__(scope)
             inner.assert_called_once_with(scope)
-            self.assertEqual(AnonymousUser, scope["user"])
+            self.assertFalse("user" in scope)
 
     def test__call__no_cookies(self):
         """Test the __call__ method if there are no cookies at all."""
@@ -71,4 +70,4 @@ class TestChannelsJwtMiddleware(TestCase):
             validate.return_value = {"user": None}
             uut.__call__(scope)
             inner.assert_called_once_with(scope)
-            self.assertEqual(AnonymousUser, scope["user"])
+            self.assertFalse("user" in scope)

--- a/middleware/tests/test_channels_oauth2_middleware.py
+++ b/middleware/tests/test_channels_oauth2_middleware.py
@@ -1,6 +1,5 @@
 """Channels OAuth2 Middleware test models."""
 from unittest.mock import MagicMock, patch
-from django.contrib.auth.models import AnonymousUser
 from test_plus.test import TestCase
 
 
@@ -62,7 +61,7 @@ class TestChannelsOauth2Middleware(TestCase):
 
             uut.__call__(scope)
             inner.assert_called_once_with(scope)
-            self.assertEqual(AnonymousUser, scope["user"])
+            self.assertFalse("user" in scope)
 
     def test__call__no_token(self):
         """Test the __call__ method when there is no token."""
@@ -71,4 +70,4 @@ class TestChannelsOauth2Middleware(TestCase):
         scope = {"path": "/asdf"}
         uut.__call__(scope)
         inner.assert_called_once_with(scope)
-        self.assertEqual(AnonymousUser, scope["user"])
+        self.assertFalse("user" in scope)

--- a/mission_control/templates/rover_settings.html
+++ b/mission_control/templates/rover_settings.html
@@ -54,6 +54,11 @@
         <button class="btn btn-secondary" id="download-env">{% trans "Download Credentials" %}</button>
       </div>
     </div>
+    <div class="row">
+      <div class="col-md-12">
+        <button class="btn btn-secondary" onclick="location.href = '{% url 'realtime:debug-room' room_name=client_id %}';" id="debug-rover">{% trans "Debug" %}</button>
+      </div>
+    </div>
   {% endif %}
 {% endblock content %}
 

--- a/realtime/consumers.py
+++ b/realtime/consumers.py
@@ -48,10 +48,11 @@ class RoverConsumer(WebsocketConsumer):
     def disconnect(self, _):
         """Handle disconnections."""
         # Leave room group
-        async_to_sync(self.channel_layer.group_discard)(
-            self.room_group_name,
-            self.channel_name
-        )
+        if self.room_group_name:
+            async_to_sync(self.channel_layer.group_discard)(
+                self.room_group_name,
+                self.channel_name
+            )
 
     def receive(self, text_data=None, bytes_data=None):
         """Handle messages received via WebSocket connection."""


### PR DESCRIPTION
This PR makes the standard Django session auth work with Channels (in addition to the jwt auth used by the React app and the Oauth2 auth used by the rover). Enabling standard Django session auth allows us to view the websocket debug chatroom without having to use the React app to get a jwt first.

Support for session auth was already in place, but it was broken because the other middleware was returning `AnonymousUser` instead of `None` when they were not being used.

Also, I added a link on the old rover detail view to the debug websocket chatroom for that rover, just for my ease while debugging.