### PR TITLE
Make realtime pass whole JSON messages

### DIFF
--- a/realtime/consumers.py
+++ b/realtime/consumers.py
@@ -55,23 +55,17 @@ class RoverConsumer(WebsocketConsumer):
 
     def receive(self, text_data=None, bytes_data=None):
         """Handle messages received via WebSocket connection."""
-        text_data_json = json.loads(text_data)
-        message_raw = text_data_json['message']
 
         # Send message to room group
         async_to_sync(self.channel_layer.group_send)(
             self.room_group_name,
             {
                 'type': 'group_message',
-                'message': message_raw
+                'body': text_data
             }
         )
 
     def group_message(self, event):
         """Handle messages received via the room group channel layer."""
-        message = event['message']
-
         # Send message to WebSocket
-        self.send(text_data=json.dumps({
-            'message': message
-        }))
+        self.send(text_data=event['body'])

--- a/realtime/consumers.py
+++ b/realtime/consumers.py
@@ -1,5 +1,4 @@
 """Consumers for Realtime app."""
-import json
 import logging
 from asgiref.sync import async_to_sync
 from channels.generic.websocket import WebsocketConsumer
@@ -56,7 +55,6 @@ class RoverConsumer(WebsocketConsumer):
 
     def receive(self, text_data=None, bytes_data=None):
         """Handle messages received via WebSocket connection."""
-
         # Send message to room group
         async_to_sync(self.channel_layer.group_send)(
             self.room_group_name,

--- a/realtime/templates/realtime/room.html
+++ b/realtime/templates/realtime/room.html
@@ -22,9 +22,7 @@
         '/ws/realtime/' + roomName + '/');
 
     chatSocket.onmessage = function(e) {
-        var data = JSON.parse(e.data);
-        var message = data['message'];
-        document.querySelector('#chat-log').value += (message + '\n');
+        document.querySelector('#chat-log').value += (e.data + '\n');
     };
 
     chatSocket.onclose = function(e) {
@@ -42,7 +40,7 @@
         var messageInputDom = document.querySelector('#chat-message-input');
         var message = messageInputDom.value;
         chatSocket.send(JSON.stringify({
-            'message': message
+            'debug-message': message
         }));
 
         messageInputDom.value = '';

--- a/realtime/templates/realtime/room.html
+++ b/realtime/templates/realtime/room.html
@@ -40,7 +40,8 @@
         var messageInputDom = document.querySelector('#chat-message-input');
         var message = messageInputDom.value;
         chatSocket.send(JSON.stringify({
-            'debug-message': message
+            'type': 'debug-message',
+            'message': message
         }));
 
         messageInputDom.value = '';


### PR DESCRIPTION
Before, the realtime websocket consume tried to extract a `message` field from the incoming JSON payload and echoed it to all clients in the group.

This PR makes it echo the entire JSON payload instead. This will allow us to define a JSON protocol between clients.

The result looks like this:
![image](https://user-images.githubusercontent.com/976857/50566483-0bc2fd00-0d00-11e9-9fbd-dfa5601ed8b6.png)

