### PR TITLE
Create alpha deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,17 @@ deploy:
       secure: NDD69o8NxncxdsqxeEL574kqoQ27jiN0K0U53dUWnjLrl1SVOg+8WRITsyU5e9DS4hzFiKWO5qOkbnh9xoKLRO/sYRxUGOwW5ZKxqkXWHFpyL/uIs2KpzmXRcaJSs3iYmowrbniKI7awH31HIvPM6EbX2EsDlb89nb2C7FNUaAlt+HZ6cwSBJsMBoQPuEe7nw5TDjZBYBhWjFfuK+MJTXc3quB2msXuBsdwvobg0AvPHEWAQl5Yyamj182Zc0DveqEeB0HbBUU2eZDvZTJclL99iBQPGiUuXfU71j5e9dg0VlF+GqY85b9kkYjoFndMWLBqCDL3855KqRIg6ouqsJsvPCTD+s4f0DNvvqt4H30T56gq8IGMqS4WOWpIWFOg/g82H23MFhsrc1IwHkdxsfWwaw/IGq3fVqeahpFqQczViYdvEU0C+JOVHdKNxy8FxU7hvXB/fZSNlPy/1VniBQK6AmzP1uA/wOURG2Oo3l4jzGQ4y7A4k7wFZVSH43iZ5hKCqNcrP5skDeu43/prrCpO0E9XsjiuexCwU2cEeTAKVLrrzBNviKHPrYH8LjwZlAtioxNXSYcAvF7+z8/wLO4lHIGzU/Vi+A55vedhaFLHefWfTJW8i6LrPjTMURzsZ921ZQOKKj4q6Tfcfcl0XkSWQxPgx7qDr12ehw7Q9NZg=
     revision_type: github
     region: us-east-2
+    application: alpha-rovercode-web
+    deployment_group: alpha-rovercode-web
+    on:
+      repo: rovercode/rovercode-web
+      branch: development
+  - provider: codedeploy
+    access_key_id: AKIAIIORSR4VN3YQY2YQ
+    secret_access_key:
+      secure: NDD69o8NxncxdsqxeEL574kqoQ27jiN0K0U53dUWnjLrl1SVOg+8WRITsyU5e9DS4hzFiKWO5qOkbnh9xoKLRO/sYRxUGOwW5ZKxqkXWHFpyL/uIs2KpzmXRcaJSs3iYmowrbniKI7awH31HIvPM6EbX2EsDlb89nb2C7FNUaAlt+HZ6cwSBJsMBoQPuEe7nw5TDjZBYBhWjFfuK+MJTXc3quB2msXuBsdwvobg0AvPHEWAQl5Yyamj182Zc0DveqEeB0HbBUU2eZDvZTJclL99iBQPGiUuXfU71j5e9dg0VlF+GqY85b9kkYjoFndMWLBqCDL3855KqRIg6ouqsJsvPCTD+s4f0DNvvqt4H30T56gq8IGMqS4WOWpIWFOg/g82H23MFhsrc1IwHkdxsfWwaw/IGq3fVqeahpFqQczViYdvEU0C+JOVHdKNxy8FxU7hvXB/fZSNlPy/1VniBQK6AmzP1uA/wOURG2Oo3l4jzGQ4y7A4k7wFZVSH43iZ5hKCqNcrP5skDeu43/prrCpO0E9XsjiuexCwU2cEeTAKVLrrzBNviKHPrYH8LjwZlAtioxNXSYcAvF7+z8/wLO4lHIGzU/Vi+A55vedhaFLHefWfTJW8i6LrPjTMURzsZ921ZQOKKj4q6Tfcfcl0XkSWQxPgx7qDr12ehw7Q9NZg=
+    revision_type: github
+    region: us-east-2
     application: beta-rovercode-web
     deployment_group: beta-rovercode-web
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ deploy:
     deployment_group: alpha-rovercode-web
     on:
       repo: rovercode/rovercode-web
-      branch: development
+      branch: alpha
   - provider: codedeploy
     access_key_id: AKIAIIORSR4VN3YQY2YQ
     secret_access_key:


### PR DESCRIPTION
ThisThis adds another AWS CodeDeploy Travis deploy for an alpha deployment to use with the new UI.

It deploys the alpha branch. Right now it's the same as the development, but this will give us a branch to start trying out removing nginx from the docker image.