### PR TITLE
Expose django ports in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       context: .
       dockerfile: ./compose/django/Dockerfile
     user: django
+    ports:
+      - "0.0.0.0:5000:5000"
     depends_on:
       - postgres
       - redis
@@ -28,6 +30,8 @@ services:
       context: .
       dockerfile: ./compose/django/Dockerfile
     user: django
+    ports:
+      - "0.0.0.0:6000:6000"
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
This exposes ports 5000 and 6000 from inside the Docker containers. This is necessary, because we now use CloudFront as the router instead of Nginx.