### PR TITLE
Fix rover app creation user bug

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -42,6 +42,9 @@ class TestRoverViewSet(BaseAuthenticatedTestCase):
         creation_time = dateutil.parser.parse(response.data['last_checkin'])
         self.assertEqual(response.status_code, 201)
 
+        application = Application.objects.get(client_id=response.data['client_id'])
+        self.assertEqual(application.user.id, self.admin.id)
+
         # Try and fail to create the same rover again
         with self.assertRaises(IntegrityError):
             self.client.post(reverse('api:v1:rover-list'), rover_info)

--- a/mission_control/serializers.py
+++ b/mission_control/serializers.py
@@ -30,10 +30,10 @@ class RoverSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         """Create an oauth application when the Rover is created."""
-        user = validated_data.get('user')
+        owner = validated_data.get('owner')
         name = validated_data.get('name')
         oauth_application = Application.objects.create(
-            user=user,
+            user=owner,
             authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
             client_type=Application.CLIENT_CONFIDENTIAL,
             name=name


### PR DESCRIPTION
This fixes a bug that caused Rover oauth applications to be created with `None` user.

It also adds to the test a section that would have caught this bug.