### PR TITLE
Correctly handle user adding rover with same name

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -6,7 +6,6 @@ import json
 
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
-from django.db.utils import IntegrityError
 from urllib.parse import urlencode
 
 from oauth2_provider.models import Application
@@ -43,8 +42,8 @@ class TestRoverViewSet(BaseAuthenticatedTestCase):
         self.assertEqual(response.status_code, 201)
 
         # Try and fail to create the same rover again
-        with self.assertRaises(IntegrityError):
-            self.client.post(reverse('api:v1:rover-list'), rover_info)
+        response = self.client.post(reverse('api:v1:rover-list'), rover_info)
+        self.assertEqual(response.status_code, 400)
 
         # Update the rover
         response = self.client.put(


### PR DESCRIPTION
I think this needs to be fixed as well. The API should return the `400` when a duplicate name is used. It previously had an `IntegrityError` which probably would've been a `500` response