### PR TITLE
Customize pagination

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -117,6 +117,7 @@ class TestRoverViewSet(BaseAuthenticatedTestCase):
         )
         response = self.get(reverse('api:v1:rover-list'))
         self.assertEqual(200, response.status_code)
+        self.assertEqual(1, response.json()['total_pages'])
         self.assertEqual(1, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['name'], 'rover')
         self.assertEqual(response.json()['results'][0]['owner'], self.admin.id)
@@ -138,6 +139,7 @@ class TestRoverViewSet(BaseAuthenticatedTestCase):
         response = self.get(
             reverse('api:v1:rover-list') + '?name=' + rover2.name)
         self.assertEqual(200, response.status_code)
+        self.assertEqual(1, response.json()['total_pages'])
         self.assertEqual(1, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['name'], 'rover2')
         self.assertEqual(response.json()['results'][0]['owner'], self.admin.id)
@@ -171,6 +173,7 @@ class TestRoverViewSet(BaseAuthenticatedTestCase):
         response = self.get(
             reverse('api:v1:rover-list') + '?client_id=' + rover2.oauth_application.client_id)
         self.assertEqual(200, response.status_code)
+        self.assertEqual(1, response.json()['total_pages'])
         self.assertEqual(1, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['name'], 'rover2')
         self.assertEqual(response.json()['results'][0]['owner'], self.admin.id)
@@ -201,6 +204,7 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
         )
         response = self.get(reverse('api:v1:blockdiagram-list'))
         self.assertEqual(200, response.status_code)
+        self.assertEqual(1, response.json()['total_pages'])
         self.assertEqual(2, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['id'], bd1.id)
         self.assertEqual(response.json()['results'][0]['user'], self.admin.id)
@@ -231,6 +235,7 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
             reverse('api:v1:blockdiagram-list') +
             '?user=' + str(user1.id))
         self.assertEqual(200, response.status_code)
+        self.assertEqual(1, response.json()['total_pages'])
         self.assertEqual(1, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['id'], bd.id)
         self.assertEqual(response.json()['results'][0]['user'], user1.id)
@@ -256,6 +261,7 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
             reverse('api:v1:blockdiagram-list') +
             '?user__not=' + str(user1.id))
         self.assertEqual(200, response.status_code)
+        self.assertEqual(1, response.json()['total_pages'])
         self.assertEqual(1, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['id'], bd.id)
         self.assertEqual(response.json()['results'][0]['user'], self.admin.id)

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -297,7 +297,7 @@ REST_FRAMEWORK = {
         'rest_framework.filters.OrderingFilter',
         'rest_framework.filters.SearchFilter',
     ),
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'mission_control.pagination.CustomPagination',
     'PAGE_SIZE': 15,
 }
 

--- a/mission_control/pagination.py
+++ b/mission_control/pagination.py
@@ -1,0 +1,22 @@
+"""Mission Control pagination."""
+from collections import OrderedDict
+
+from rest_framework import pagination
+from rest_framework.response import Response
+
+
+class CustomPagination(pagination.PageNumberPagination):
+    """Pagination that allows settings page size and displays total pages."""
+
+    page_size_query_param = 'size'
+    max_page_size = 100
+
+    def get_paginated_response(self, data):
+        """Paginated response."""
+        return Response(OrderedDict([
+            ('count', self.page.paginator.count),
+            ('total_pages', self.page.paginator.num_pages),
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('results', data)
+        ]))


### PR DESCRIPTION
Adds `total_pages` to the output and allows setting `size` to change the page size:
![image](https://user-images.githubusercontent.com/1184314/55122086-dd24aa80-50d3-11e9-8f08-dcd9a6a2e2a4.png)

![image](https://user-images.githubusercontent.com/1184314/55122022-9cc52c80-50d3-11e9-8d17-2b56d8a98b6f.png)
