### PR TITLE
Program serialization change

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -207,12 +207,16 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
         self.assertEqual(1, response.json()['total_pages'])
         self.assertEqual(2, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['id'], bd1.id)
-        self.assertEqual(response.json()['results'][0]['user'], self.admin.id)
+        self.assertDictEqual(response.json()['results'][0]['user'], {
+            'username': self.admin.username,
+        })
         self.assertEqual(response.json()['results'][0]['name'], 'test')
         self.assertEqual(
             response.json()['results'][0]['content'], '<xml></xml>')
         self.assertEqual(response.json()['results'][1]['id'], bd2.id)
-        self.assertEqual(response.json()['results'][1]['user'], user.id)
+        self.assertDictEqual(response.json()['results'][1]['user'], {
+            'username': user.username,
+        })
         self.assertEqual(response.json()['results'][1]['name'], 'test1')
         self.assertEqual(
             response.json()['results'][1]['content'], '<xml></xml>')
@@ -238,7 +242,9 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
         self.assertEqual(1, response.json()['total_pages'])
         self.assertEqual(1, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['id'], bd.id)
-        self.assertEqual(response.json()['results'][0]['user'], user1.id)
+        self.assertDictEqual(response.json()['results'][0]['user'], {
+            'username': user1.username,
+        })
         self.assertEqual(response.json()['results'][0]['name'], 'test2')
         self.assertEqual(
             response.json()['results'][0]['content'], '<xml></xml>')
@@ -264,7 +270,9 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
         self.assertEqual(1, response.json()['total_pages'])
         self.assertEqual(1, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['id'], bd.id)
-        self.assertEqual(response.json()['results'][0]['user'], self.admin.id)
+        self.assertDictEqual(response.json()['results'][0]['user'], {
+            'username': self.admin.username,
+        })
         self.assertEqual(response.json()['results'][0]['name'], 'test1')
         self.assertEqual(
             response.json()['results'][0]['content'], '<xml></xml>')

--- a/mission_control/serializers.py
+++ b/mission_control/serializers.py
@@ -1,4 +1,5 @@
 """Mission Control serializers."""
+from django.contrib.auth import get_user_model
 from django.db.utils import IntegrityError
 from rest_framework import serializers
 from oauth2_provider.models import Application
@@ -45,12 +46,23 @@ class RoverSerializer(serializers.ModelSerializer):
                 'There is already a rover with that name')
 
 
+class UserSerializer(serializers.ModelSerializer):
+    """User model serializer."""
+
+    class Meta:
+        """Meta class."""
+
+        model = get_user_model()
+        fields = ('username', )
+
+
 class BlockDiagramSerializer(serializers.ModelSerializer):
     """Block diagram model serializer."""
+
+    user = UserSerializer(read_only=True)
 
     class Meta:
         """Meta class."""
 
         model = BlockDiagram
         fields = '__all__'
-        read_only_fields = ('user',)


### PR DESCRIPTION
Closes #221 

**This is a breaking change for the API**

Expands the program serialization to contain the `username`.
![image](https://user-images.githubusercontent.com/1184314/55598164-5a2cd100-571f-11e9-9c74-2dde2393d231.png)
