### PR TITLE
Cleanup dev.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq build-essential gettext python-dev zlib1g-dev libpq-dev
   xvfb
-- sudo apt-get install -qq libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms1-dev
+- sudo apt-get install -qq libtiff5-dev libjpeg8-dev libfreetype6-dev liblcms2-dev
   libwebp-dev
 - sudo apt-get install -qq graphviz-dev python-setuptools python3-dev python-virtualenv
   python-pip

--- a/dev.yml
+++ b/dev.yml
@@ -1,17 +1,14 @@
-version: '2'
+version: '3'
 
 volumes:
   postgres_data_dev: {}
-  postgres_backup_dev: {}
+  redis_data_dev: {}
 
 services:
   postgres:
-    build: ./compose/postgres
+    image: postgres:9.6-alpine
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
-      - postgres_backup_dev:/backups
-    environment:
-      - POSTGRES_USER=rovercode_web
 
   django:
     build:
@@ -21,27 +18,26 @@ services:
     depends_on:
       - postgres
     environment:
-      POSTGRES_USER: 'rovercode_web'
       USE_DOCKER: 'yes'
       DEFAULT_ROVER_CONFIG: '{"left_eye_port": 1, "right_eye_port": 2, "left_motor_port": 3, "right_motor_port": 4}'
     volumes:
       - .:/app
     ports:
-      - "8000:8000"
-    links:
-      - postgres
-
-      - mailhog
+      - 8000:8000
 
   redis:
     image: redis:alpine
+    volumes:
+      - redis_data_dev:/data
 
-
-
-
+  redis-commander:
+    image: rediscommander/redis-commander
+    environment:
+      - REDIS_HOST=redis
+    ports:
+      - 8081:8081
 
   mailhog:
     image: mailhog/mailhog
     ports:
-      - "8025:8025"
-
+      - 8025:8025


### PR DESCRIPTION
- Persist data for redis
- Remove custom built postgres image
**Warning**: This will clear the local development database since this reverts back to the default database name of `postgres`
- Add redis-commander for debugging redis

We can remove `compose/nginx` and `compose/postgres` once `docker-compose.yml` no longer depends on them