### PR TITLE
Fixing outdated setup instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,10 +32,10 @@ Install `docker <https://docs.docker.com/engine/installation/>`_ and `docker-com
 
 .. code-block:: bash
 
-    $ git clone --recursive https://github.com/aninternetof/rovercode-web.git && cd rovercode-web
+    $ git clone --recursive https://github.com/rovercode/rovercode-web.git && cd rovercode-web
     $ sudo docker-compose -f dev.yml build
     $ sudo docker-compose -f dev.yml up
-    $ google-chrome localhost:8000
+    $ google-chrome localhost:8000/docs
 
 Basic Commands
 --------------


### PR DESCRIPTION
I changed this two items in the README.RST because they were outdated and didn't work.