### PR TITLE
Add ECR deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ tests.xml
 .cache/
 
 staticfiles/
+
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,3 @@ tests.xml
 .cache/
 
 staticfiles/
-
-Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ python:
 - '3.6'
 deploy:
   - provider: script
-    script: bash ecr-deploy.sh debugging
+    script: echo "Deploying to ECR" && bash ecr-deploy.sh debugging
     on:
       branch: add-ecr-deploy
   - provider: codedeploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ python:
 - '3.6'
 deploy:
   - provider: script
-    script: echo "Deploying to ECR" && bash ecr-deploy.sh debugging
+    script: bash ecr-deploy.sh debugging
     on:
       branch: add-ecr-deploy
   - provider: codedeploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: true
 services:
 - postgresql
+- docker
 addons:
   postgresql: "9.4"
 env:
@@ -36,6 +37,10 @@ language: python
 python:
 - '3.6'
 deploy:
+  - provider: script
+    script: bash ecr-deploy.sh debugging
+    on:
+      branch: add-ecr-deploy
   - provider: codedeploy
     access_key_id: AKIAIIORSR4VN3YQY2YQ
     secret_access_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,17 @@ python:
 - '3.6'
 deploy:
   - provider: script
-    script: bash ecr-deploy.sh debugging
+    script: bash ecr-deploy.sh alpha
     on:
-      branch: add-ecr-deploy
+      branch: alpha
+  - provider: script
+    script: bash ecr-deploy.sh beta
+    on:
+      branch: beta
+  - provider: script
+    script: bash ecr-deploy.sh prod
+    on:
+      branch: prod
   - provider: codedeploy
     access_key_id: AKIAIIORSR4VN3YQY2YQ
     secret_access_key:

--- a/ecr-deploy.sh
+++ b/ecr-deploy.sh
@@ -6,8 +6,7 @@ fi
 
 echo "Deploying $1 image to ECR"
 
-pip install --user awscli
-export PATH=$PATH:$HOME/.local/bin
+pip install awscli
 
 cp ./compose/django/Dockerfile .
 docker build -t 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode:$1 .

--- a/ecr-deploy.sh
+++ b/ecr-deploy.sh
@@ -1,0 +1,12 @@
+if [[ $# < 1 ]]
+then
+    echo "Requires one argument: the name of the environment."
+    exit 1
+fi
+
+echo "Deploying $1 image to ECR"
+
+cp /compose/django/Dockerfile .
+docker build -t 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode:$1 .
+eval $(aws ecr get-login --region us-east-2 --no-include-email) # requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secret environment variable set in Travis
+docker push 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode:$1

--- a/ecr-deploy.sh
+++ b/ecr-deploy.sh
@@ -9,6 +9,6 @@ echo "Deploying $1 image to ECR"
 pip install awscli
 
 cp ./compose/django/Dockerfile .
-docker build -t 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode:$1 .
+docker build -t 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode-web-service:$1 .
 eval $(aws ecr get-login --region us-east-2 --no-include-email) # requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secret environment variable set in Travis
-docker push 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode:$1
+docker push 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode-web-service:$1

--- a/ecr-deploy.sh
+++ b/ecr-deploy.sh
@@ -8,7 +8,6 @@ echo "Deploying $1 image to ECR"
 
 pip install awscli
 
-cp ./compose/django/Dockerfile .
-docker build -t 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode-web-service:$1 .
+docker build -t 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode-web-service:$1 -f ./compose/django/Dockerfile .
 eval $(aws ecr get-login --region us-east-2 --no-include-email) # requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secret environment variable set in Travis
 docker push 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode-web-service:$1

--- a/ecr-deploy.sh
+++ b/ecr-deploy.sh
@@ -6,7 +6,10 @@ fi
 
 echo "Deploying $1 image to ECR"
 
-cp /compose/django/Dockerfile .
+pip install --user awscli
+export PATH=$PATH:$HOME/.local/bin
+
+cp ./compose/django/Dockerfile .
 docker build -t 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode:$1 .
 eval $(aws ecr get-login --region us-east-2 --no-include-email) # requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secret environment variable set in Travis
 docker push 795223264977.dkr.ecr.us-east-2.amazonaws.com/rovercode:$1


### PR DESCRIPTION
This PR makes travis build and deploy the Docker image to our private Elastic Container Repository.

It relies on finding AWS role credentials in Travis' secret environment (newer feature of Travis, which is pretty cool). I've added them there.

We tag the image as either `alpha`, `beta`, or `prod`.

[Here is an example of a successful deploy on my working branch](https://travis-ci.org/rovercode/rovercode-web/builds/555073108).