### PR TITLE
Off instance redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,18 +37,19 @@ language: python
 python:
 - '3.6'
 deploy:
-  - provider: script
-    script: bash ecr-deploy.sh alpha
-    on:
-      branch: alpha
-  - provider: script
-    script: bash ecr-deploy.sh beta
-    on:
-      branch: beta
-  - provider: script
-    script: bash ecr-deploy.sh prod
-    on:
-      branch: prod
+# TODO: Re-add when ECR exists
+#  - provider: script
+#    script: bash ecr-deploy.sh alpha
+#    on:
+#      branch: alpha
+#  - provider: script
+#    script: bash ecr-deploy.sh beta
+#    on:
+#      branch: beta
+#  - provider: script
+#    script: bash ecr-deploy.sh prod
+#    on:
+#      branch: prod
   - provider: codedeploy
     access_key_id: AKIAIIORSR4VN3YQY2YQ
     secret_access_key:

--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -6,7 +6,6 @@ cmd="$@"
 # Since docker-compose relies heavily on environment variables itself for configuration, we'd have to define multiple
 # environment variables just to support cookiecutter out of the box. That makes no sense, so this little entrypoint
 # does all this for us.
-export REDIS_URL=redis://redis:6379
 
 # the official postgres image uses 'postgres' as default user if not set explictly.
 if [ -z "$POSTGRES_USER" ]; then

--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -2,11 +2,6 @@
 set -e
 cmd="$@"
 
-# This entrypoint is used to play nicely with the current cookiecutter configuration.
-# Since docker-compose relies heavily on environment variables itself for configuration, we'd have to define multiple
-# environment variables just to support cookiecutter out of the box. That makes no sense, so this little entrypoint
-# does all this for us.
-
 # the official postgres image uses 'postgres' as default user if not set explictly.
 if [ -z "$POSTGRES_USER" ]; then
     export POSTGRES_USER=postgres

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -215,7 +215,7 @@ WSGI_APPLICATION = 'config.wsgi.application'
 
 ASGI_APPLICATION = 'config.asgi.application'
 
-redis_url = urlparse(env('REDIS_URL', default='redis://127.0.0.1:6379'))
+redis_url = urlparse(env('REDIS_URL', default='redis://redis:6379'))
 REDIS_HOST = redis_url.hostname
 REDIS_PORT = redis_url.port
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -139,7 +139,7 @@ DATABASES['default'] = env.db('DATABASE_URL')
 # CACHING
 # ------------------------------------------------------------------------------
 
-REDIS_LOCATION = '{0}/{1}'.format(env('REDIS_URL', default='redis://127.0.0.1:6379'), 0)
+REDIS_LOCATION = '{0}/{1}'.format(env('REDIS_URL', default='redis://redis:6379'), 0)
 # Heroku URL does not pass the DB number, so we parse it in
 CACHES = {
     'default': {

--- a/env.example
+++ b/env.example
@@ -8,6 +8,9 @@ POSTGRES_PASSWORD=mysecretpass
 POSTGRES_USER=postgresuser
 POSTGRES_USE_AWS_SSL=false
 
+# Distributed Memory
+REDIS_URL=redis://my-redis.xxxxx.xx.xxxx.use2.cache.amazonaws.com:6379
+
 # General settings
 DJANGO_ADMIN_URL=
 DJANGO_SETTINGS_MODULE=config.settings.production


### PR DESCRIPTION
We had already set up config/settings/common.py to read the Redis URL from the environment, but it was being overwritten in entrypoint.sh. This gets rid of the overwriting export in entrypoint.sh.

I created an ElastiCache Redis instance and ssh'd into our beta EC2 to test this change.

We can leave redis in the docker-compose for now so that the alpha environment can use on-instance redis to save money.

---------------

Unrelated: I also commented the ECR deploy until we're ready to resume work on the ECS cluster.