### PR TITLE
Allow shared users to connect to ws

### DIFF
--- a/realtime/consumers.py
+++ b/realtime/consumers.py
@@ -29,7 +29,8 @@ class RoverConsumer(WebsocketConsumer):
             self.close(code=404)
             return
 
-        if rover.owner.id != user.id:
+        shared_user_ids = [user.id for user in rover.shared_users.all()]
+        if not (rover.owner.id == user.id or user.id in shared_user_ids):
             self.close(code=403)
             return
 

--- a/realtime/consumers.py
+++ b/realtime/consumers.py
@@ -29,8 +29,8 @@ class RoverConsumer(WebsocketConsumer):
             self.close(code=404)
             return
 
-        shared_user_ids = [user.id for user in rover.shared_users.all()]
-        if not (rover.owner.id == user.id or user.id in shared_user_ids):
+        is_shared_user = rover.shared_users.filter(id=user.id).exists()
+        if not (rover.owner.id == user.id or is_shared_user):
             self.close(code=403)
             return
 

--- a/realtime/tests/test_rover_consumer.py
+++ b/realtime/tests/test_rover_consumer.py
@@ -67,7 +67,7 @@ async def test_rover_consumer_shared_user():
         local_ip='8.8.8.8',
         oauth_application=oauth_app,
     )
-    rover.shared_users.set([shared_user])
+    rover.shared_users.add(shared_user)
     application = MockAuthMiddleware(URLRouter([
         url(r'^ws/realtime/(?P<room_name>[^/]+)/$', RoverConsumer),
     ]))

--- a/realtime/tests/test_rover_consumer.py
+++ b/realtime/tests/test_rover_consumer.py
@@ -49,6 +49,45 @@ async def test_rover_consumer():
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
+async def test_rover_consumer_shared_user():
+    """Test sending a message to the room as a shared user."""
+    creating_user = User.objects.create(id=MOCK_USER_ID + 100,
+                                        username="creator")
+    shared_user = User.objects.create(id=MOCK_USER_ID,
+                                      username="creator's buddy")
+    oauth_app = Application.objects.create(
+        user=creating_user,
+        authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        client_type=Application.CLIENT_CONFIDENTIAL,
+        name='rover'
+    )
+    rover = Rover.objects.create(
+        name='rover',
+        owner=creating_user,
+        local_ip='8.8.8.8',
+        oauth_application=oauth_app,
+    )
+    rover.shared_users.set([shared_user])
+    application = MockAuthMiddleware(URLRouter([
+        url(r'^ws/realtime/(?P<room_name>[^/]+)/$', RoverConsumer),
+    ]))
+    communicator = WebsocketCommunicator(
+        application,
+        "/ws/realtime/{}/".format(oauth_app.client_id)
+    )
+    connected, _ = await communicator.connect()
+    assert connected
+    message = json.dumps({"message": "hello"})
+    # Test sending text
+    await communicator.send_to(text_data=message)
+    response = await communicator.receive_from()
+    assert response == message
+    # Close
+    await communicator.disconnect()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
 async def test_rover_consumer_no_user():
     """Test trying to connect while unauthenticated."""
     User.objects.create(id=MOCK_USER_ID)


### PR DESCRIPTION
This makes the websocket security check allow shared users. I realized I forgotten about this in the last shared-users PR.

