### PR TITLE
Remove pagination from tag list

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -135,3 +135,4 @@ class TagViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = ('name',)
     ordering = ('name',)
     search_fields = ('name',)
+    pagination_class = None


### PR DESCRIPTION
Only real use is to have all the tags so paginating just causes more API calls