### PR TITLE
Use correct route for password reset

### DIFF
--- a/rovercode_web/templates/registration/password_reset_email.html
+++ b/rovercode_web/templates/registration/password_reset_email.html
@@ -1,0 +1,14 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+
+{% trans "Please go to the following page and choose a new password:" %}
+{% block reset_link %}
+{{ protocol }}://{{ domain }}/accounts/reset/callback/{{ uid }}/{{ token }}
+{% endblock %}
+{% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
+
+{% trans "Thanks for using our site!" %}
+
+{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
+
+{% endautoescape %}


### PR DESCRIPTION
This sends the password reset to the correct UI route to enter the new password