### PR TITLE
Make profanity-check host an env variable

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -318,7 +318,7 @@ SOCIALACCOUNT_PROVIDERS = {
 
 # OTHER SERVICES
 # ------------------------------------------------------------------------------
-PROFANITY_CHECK_SERVICE_HOST = env('PROFANITY_CHECK_HOST', default='http://profanity-check:8000')
+PROFANITY_CHECK_SERVICE_HOST = env('PROFANITY_CHECK_SERVICE_HOST', default='http://profanity-check:8000')
 
 # JWT CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -316,6 +316,10 @@ SOCIALACCOUNT_PROVIDERS = {
     }
 }
 
+# OTHER SERVICES
+# ------------------------------------------------------------------------------
+PROFANITY_CHECK_HOST = env('PROFANITY_CHECK_HOST', default='http://profanity-check:8000')
+
 # JWT CONFIGURATION
 # ------------------------------------------------------------------------------
 JWT_AUTH = {

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -318,7 +318,7 @@ SOCIALACCOUNT_PROVIDERS = {
 
 # OTHER SERVICES
 # ------------------------------------------------------------------------------
-PROFANITY_CHECK_HOST = env('PROFANITY_CHECK_HOST', default='http://profanity-check:8000')
+PROFANITY_CHECK_SERVICE_HOST = env('PROFANITY_CHECK_HOST', default='http://profanity-check:8000')
 
 # JWT CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/env.example
+++ b/env.example
@@ -35,5 +35,8 @@ DJANGO_ACCOUNT_ALLOW_REGISTRATION=True
 # Sentry
 DJANGO_SENTRY_DSN=
 
+# Other services
+PROFANITY_CHECK_SERVICE_HOST=http://profanity-server.aws.com:80
+
 
 

--- a/mission_control/signals/handlers.py
+++ b/mission_control/signals/handlers.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 def update_block_diagram(sender, instance, **kwargs):
     """Handle changes to BlockDiagram model."""
     response = requests.post(
-        'http://profanity-check:8000/censor-word/{}'.format(instance.name))
+        '{}/censor-word/{}'.format(settings.PROFANITY_CHECK_HOST, instance.name))
 
     if response.status_code != 200:
         LOGGER.error(

--- a/mission_control/signals/handlers.py
+++ b/mission_control/signals/handlers.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 def update_block_diagram(sender, instance, **kwargs):
     """Handle changes to BlockDiagram model."""
     response = requests.post(
-        '{}/censor-word/{}'.format(settings.PROFANITY_CHECK_HOST, instance.name))
+        '{}/censor-word/{}'.format(settings.PROFANITY_CHECK_SERVICE_HOST, instance.name))
 
     if response.status_code != 200:
         LOGGER.error(


### PR DESCRIPTION
When the profanity-check service is not running on the same instance as the API, we need to be able to tell the API where to find it. This creates an environment variable for it.

I was playing with ECS some today. I think we'll set this new variable to the URL of the ALB, and the ALB will have a rule that routes the `/censor-word` path to the profanity service's target group.