### PR TITLE
Remove legacy dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     build: ./compose/nginx
     depends_on:
       - django
-      - django-websockets
 
     ports:
       - "0.0.0.0:80:80"


### PR DESCRIPTION
This causes the deploy to fail since the dependency does not exist