### PR TITLE
Get rid of CodeDeploy deploys for beta and prod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,28 +55,6 @@ deploy:
       secure: NDD69o8NxncxdsqxeEL574kqoQ27jiN0K0U53dUWnjLrl1SVOg+8WRITsyU5e9DS4hzFiKWO5qOkbnh9xoKLRO/sYRxUGOwW5ZKxqkXWHFpyL/uIs2KpzmXRcaJSs3iYmowrbniKI7awH31HIvPM6EbX2EsDlb89nb2C7FNUaAlt+HZ6cwSBJsMBoQPuEe7nw5TDjZBYBhWjFfuK+MJTXc3quB2msXuBsdwvobg0AvPHEWAQl5Yyamj182Zc0DveqEeB0HbBUU2eZDvZTJclL99iBQPGiUuXfU71j5e9dg0VlF+GqY85b9kkYjoFndMWLBqCDL3855KqRIg6ouqsJsvPCTD+s4f0DNvvqt4H30T56gq8IGMqS4WOWpIWFOg/g82H23MFhsrc1IwHkdxsfWwaw/IGq3fVqeahpFqQczViYdvEU0C+JOVHdKNxy8FxU7hvXB/fZSNlPy/1VniBQK6AmzP1uA/wOURG2Oo3l4jzGQ4y7A4k7wFZVSH43iZ5hKCqNcrP5skDeu43/prrCpO0E9XsjiuexCwU2cEeTAKVLrrzBNviKHPrYH8LjwZlAtioxNXSYcAvF7+z8/wLO4lHIGzU/Vi+A55vedhaFLHefWfTJW8i6LrPjTMURzsZ921ZQOKKj4q6Tfcfcl0XkSWQxPgx7qDr12ehw7Q9NZg=
     revision_type: github
     region: us-east-2
-    application: beta-rovercode-web
-    deployment_group: beta-rovercode-web
-    on:
-      repo: rovercode/rovercode-web
-      branch: development
-  - provider: codedeploy
-    access_key_id: AKIAIIORSR4VN3YQY2YQ
-    secret_access_key:
-      secure: NDD69o8NxncxdsqxeEL574kqoQ27jiN0K0U53dUWnjLrl1SVOg+8WRITsyU5e9DS4hzFiKWO5qOkbnh9xoKLRO/sYRxUGOwW5ZKxqkXWHFpyL/uIs2KpzmXRcaJSs3iYmowrbniKI7awH31HIvPM6EbX2EsDlb89nb2C7FNUaAlt+HZ6cwSBJsMBoQPuEe7nw5TDjZBYBhWjFfuK+MJTXc3quB2msXuBsdwvobg0AvPHEWAQl5Yyamj182Zc0DveqEeB0HbBUU2eZDvZTJclL99iBQPGiUuXfU71j5e9dg0VlF+GqY85b9kkYjoFndMWLBqCDL3855KqRIg6ouqsJsvPCTD+s4f0DNvvqt4H30T56gq8IGMqS4WOWpIWFOg/g82H23MFhsrc1IwHkdxsfWwaw/IGq3fVqeahpFqQczViYdvEU0C+JOVHdKNxy8FxU7hvXB/fZSNlPy/1VniBQK6AmzP1uA/wOURG2Oo3l4jzGQ4y7A4k7wFZVSH43iZ5hKCqNcrP5skDeu43/prrCpO0E9XsjiuexCwU2cEeTAKVLrrzBNviKHPrYH8LjwZlAtioxNXSYcAvF7+z8/wLO4lHIGzU/Vi+A55vedhaFLHefWfTJW8i6LrPjTMURzsZ921ZQOKKj4q6Tfcfcl0XkSWQxPgx7qDr12ehw7Q9NZg=
-    revision_type: github
-    region: us-east-2
-    application: rovercode-web
-    deployment_group: rovercode-web
-    on:
-      repo: rovercode/rovercode-web
-      branch: master
-  - provider: codedeploy
-    access_key_id: AKIAIIORSR4VN3YQY2YQ
-    secret_access_key:
-      secure: NDD69o8NxncxdsqxeEL574kqoQ27jiN0K0U53dUWnjLrl1SVOg+8WRITsyU5e9DS4hzFiKWO5qOkbnh9xoKLRO/sYRxUGOwW5ZKxqkXWHFpyL/uIs2KpzmXRcaJSs3iYmowrbniKI7awH31HIvPM6EbX2EsDlb89nb2C7FNUaAlt+HZ6cwSBJsMBoQPuEe7nw5TDjZBYBhWjFfuK+MJTXc3quB2msXuBsdwvobg0AvPHEWAQl5Yyamj182Zc0DveqEeB0HbBUU2eZDvZTJclL99iBQPGiUuXfU71j5e9dg0VlF+GqY85b9kkYjoFndMWLBqCDL3855KqRIg6ouqsJsvPCTD+s4f0DNvvqt4H30T56gq8IGMqS4WOWpIWFOg/g82H23MFhsrc1IwHkdxsfWwaw/IGq3fVqeahpFqQczViYdvEU0C+JOVHdKNxy8FxU7hvXB/fZSNlPy/1VniBQK6AmzP1uA/wOURG2Oo3l4jzGQ4y7A4k7wFZVSH43iZ5hKCqNcrP5skDeu43/prrCpO0E9XsjiuexCwU2cEeTAKVLrrzBNviKHPrYH8LjwZlAtioxNXSYcAvF7+z8/wLO4lHIGzU/Vi+A55vedhaFLHefWfTJW8i6LrPjTMURzsZ921ZQOKKj4q6Tfcfcl0XkSWQxPgx7qDr12ehw7Q9NZg=
-    revision_type: github
-    region: us-east-2
     application: alpha-rovercode-web
     deployment_group: alpha-rovercode-web
     on:


### PR DESCRIPTION
We don't need the CodeDeploy deploys for beta and prod in Travis anymore since we have the ECR deploy.

Removing these will allow us to deploy to prod ECR without overwriting our legacy prod EC2.