### PR TITLE
Lock version of pipenv to build in Docker

### DIFF
--- a/compose/django/Dockerfile
+++ b/compose/django/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache bash ca-certificates wget shadow build-base python3-dev p
     && mv /usr/local/share/ca-certificates/rds-ca-2015-root.pem /usr/local/share/ca-certificates/rds-ca-2015-root.crt \
     && update-ca-certificates \
     && pip install --upgrade pip \
-    && pip install pipenv \
+    && pip install pipenv==2018.11.26 \
     && pipenv install --ignore-pipfile --system \
     && apk del --purge build-base python3-dev \
     && groupadd -r django \


### PR DESCRIPTION
The updated version of `pipenv` does not allow running in root which is what Docker builds do. It's a known issue that will be fixed with a new release shortly. This should fix the build for now.
https://travis-ci.org/github/rovercode/rovercode-web/builds/693209738