### PR TITLE
Only list non-reference programs in the community view

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -11,7 +11,8 @@ from rest_framework_jwt.views import verify_jwt_token
 from . import views
 
 router = routers.DefaultRouter()
-router.register(r'block-diagrams', views.BlockDiagramViewSet)
+router.register(
+    r'block-diagrams', views.BlockDiagramViewSet, basename='blockdiagram')
 router.register(r'courses', views.CourseViewSet)
 router.register(r'lessons', views.LessonViewSet)
 router.register(r'tags', views.TagViewSet)

--- a/api/views.py
+++ b/api/views.py
@@ -50,7 +50,6 @@ class BlockDiagramViewSet(viewsets.ModelViewSet):
         Update a block diagram.
     """
 
-    queryset = BlockDiagram.objects.all()
     serializer_class = BlockDiagramSerializer
     permission_classes = (permissions.IsAuthenticated, )
     filterset_class = BlockDiagramFilter
@@ -69,17 +68,19 @@ class BlockDiagramViewSet(viewsets.ModelViewSet):
             else:
                 return unique
 
+    def get_queryset(self):
+        """Return the objects available for the operation."""
+        if self.action in ['update', 'partial_update', 'destroy']:
+            return BlockDiagram.objects.filter(user=self.request.user)
+        if self.action == 'list':
+            return BlockDiagram.objects.filter(reference_of=None)
+
+        return BlockDiagram.objects.all()
+
     def perform_create(self, serializer):
         """Perform the create operation."""
         user = self.request.user
         serializer.save(user=user)
-
-    def perform_update(self, serializer):
-        """Perform the update operation."""
-        if self.get_object().user.id is not self.request.user.id:
-            raise serializers.ValidationError(
-                'You may only modify your own block diagrams')
-        serializer.save()
 
     @staticmethod
     @action(detail=True, methods=['POST'])


### PR DESCRIPTION
This will restrict the view of all block diagrams to only those created by the community and not as reference for a lesson