### PR TITLE
User stats

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -82,7 +82,6 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
         super().tearDown()
         self.patcher.stop()
 
-    @override_settings(FREE_TIER_PROGRAM_LIMIT=7)
     def test_bd(self):
         """Test the block diagram API view displays the correct items."""
         self.authenticate()
@@ -106,7 +105,6 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
         response = self.get(reverse('api:v1:blockdiagram-list'))
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, response.json()['total_pages'])
-        self.assertEqual(7, response.json()['free_max'])
         self.assertEqual(2, len(response.json()['results']))
         self.assertEqual(response.json()['results'][0]['id'], bd1.id)
         self.assertDictEqual(response.json()['results'][0]['user'], {

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -861,7 +861,7 @@ class TestUserViewSet(BaseAuthenticatedTestCase):
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(2, response.json()['block_diagram']['count'])
-        self.assertEqual(3, response.json()['block_diagram']['allowed'])
+        self.assertEqual(3, response.json()['block_diagram']['limit'])
 
     def test_stats_other_user(self):
         """Test getting other user's statistics."""

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -792,6 +792,18 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
 class TestUserViewSet(BaseAuthenticatedTestCase):
     """Tests the user API view."""
 
+    def setUp(self):
+        """Initialize the tests."""
+        super().setUp()
+        self.patcher = patch('requests.post')
+        self.mock_post = self.patcher.start()
+        self.mock_post.return_value.status_code = 404
+
+    def tearDown(self):
+        """Tear down the tests."""
+        super().tearDown()
+        self.patcher.stop()
+
     def test_modify(self):
         """Test modifying user."""
         self.authenticate()

--- a/api/views.py
+++ b/api/views.py
@@ -234,7 +234,7 @@ class UserViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):
         stats = {
             'block_diagram': {
                 'count': BlockDiagram.objects.filter(user=user).count(),
-                'allowed': settings.FREE_TIER_PROGRAM_LIMIT,
+                'limit': settings.FREE_TIER_PROGRAM_LIMIT,
             },
         }
 

--- a/mission_control/pagination.py
+++ b/mission_control/pagination.py
@@ -1,7 +1,6 @@
 """Mission Control pagination."""
 from collections import OrderedDict
 
-from django.conf import settings
 from rest_framework import pagination
 from rest_framework.response import Response
 
@@ -16,7 +15,6 @@ class CustomPagination(pagination.PageNumberPagination):
         """Paginated response."""
         return Response(OrderedDict([
             ('count', self.page.paginator.count),
-            ('free_max', settings.FREE_TIER_PROGRAM_LIMIT),
             ('total_pages', self.page.paginator.num_pages),
             ('next', self.get_next_link()),
             ('previous', self.get_previous_link()),


### PR DESCRIPTION
Creates a new endpoint to view user statistics:
`/api/v1/users/<pk>/stats/`
Currently, contains the number of programs a user has and the maximum allowed in the free tier:
```
{
    "block_diagram": {
        "limit": 5,
        "count": 120
    }
}
```