### PR TITLE
Provide 'next_url' to social login

### DIFF
--- a/authorize/tests/test_views.py
+++ b/authorize/tests/test_views.py
@@ -109,6 +109,12 @@ class CallbackUrlTestCase(TestCase):
         social_app.sites.add(Site.objects.first())
         social_app.save()
 
+        session = self.client.session
+        session['socialaccount_state'] = {
+            'next': '/test/url',
+        }, None
+        session.save()
+
         response = self.client.post(reverse('jwt:github_callback_login'), {
             'state': '1234',
             'code': '5678'
@@ -117,6 +123,8 @@ class CallbackUrlTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(responses.calls), 1)
         self.assertIn('access_token', response.json())
+        self.assertIn('next_url', response.json())
+        self.assertEqual(response.json()['next_url'], '/test/url')
 
     @responses.activate
     @patch.object(SocialLoginSerializer, 'validate')
@@ -144,6 +152,12 @@ class CallbackUrlTestCase(TestCase):
         social_app.sites.add(Site.objects.first())
         social_app.save()
 
+        session = self.client.session
+        session['socialaccount_state'] = {
+            'next': '/test/url',
+        }, None
+        session.save()
+
         response = self.client.post(reverse('jwt:google_callback_login'), {
             'state': '1234',
             'code': '5678'
@@ -152,6 +166,8 @@ class CallbackUrlTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(responses.calls), 1)
         self.assertIn('access_token', response.json())
+        self.assertIn('next_url', response.json())
+        self.assertEqual(response.json()['next_url'], '/test/url')
 
     @patch.object(SocialLogin, 'verify_and_unstash_state')
     def test_state_validation(self, mock_verify):

--- a/authorize/views.py
+++ b/authorize/views.py
@@ -22,6 +22,20 @@ class JsonAdapterView(OAuth2LoginView):
         })
 
 
+class SocialLoginViewWithNextParam(SocialLoginView):
+    """Add the 'next' parameter to the response."""
+
+    def post(self, request, *args, **kwargs):
+        """Process login. Provide the `next` parameter if it exists."""
+        state, _ = self.request.session.get(
+            'socialaccount_state', (None, None))
+
+        response = super().post(request, *args, **kwargs)
+        response.data['next_url'] = state.get('next') if state else None
+
+        return response
+
+
 class GitHubAdapter(GitHubOAuth2Adapter):
     """Customize the callback url to point to the frontend route."""
 
@@ -32,7 +46,7 @@ class GitHubAdapter(GitHubOAuth2Adapter):
         return settings.SOCIAL_CALLBACK_URL.format(service='github')
 
 
-class GitHubLogin(SocialLoginView):
+class GitHubLogin(SocialLoginViewWithNextParam):
     """Log the user in. Creates a new user account if it doesn't exist yet."""
 
     adapter_class = GitHubOAuth2Adapter
@@ -51,7 +65,7 @@ class GoogleAdapter(GoogleOAuth2Adapter):
         return settings.SOCIAL_CALLBACK_URL.format(service='google')
 
 
-class GoogleLogin(SocialLoginView):
+class GoogleLogin(SocialLoginViewWithNextParam):
     """Log the user in. Creates a new user account if it doesn't exist yet."""
 
     adapter_class = GoogleOAuth2Adapter


### PR DESCRIPTION
Stores the `next` parameter in the session. Provides the value to the frontend in the callback response after the login has succeeded.