### PR TITLE
Fix refresh and verify token views

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -9,7 +9,8 @@ from rest_framework_simplejwt.views import TokenObtainPairView
 from rest_framework_simplejwt.views import TokenRefreshView
 from rest_framework_simplejwt.views import TokenVerifyView
 
-from rovercode_web.users.utils import JwtSerializer
+from rovercode_web.users.utils import JwtObtainPairSerializer
+from rovercode_web.users.utils import JwtRefreshSerializer
 
 from . import views
 
@@ -25,17 +26,17 @@ router.register(r'users', views.UserViewSet)
 urlpatterns = [
     url(
         r'^api-token-auth/',
-        TokenObtainPairView.as_view(serializer_class=JwtSerializer),
+        TokenObtainPairView.as_view(serializer_class=JwtObtainPairSerializer),
         name='api-token-auth'
     ),
     url(
         r'^api-token-verify/',
-        TokenVerifyView.as_view(serializer_class=JwtSerializer),
+        TokenVerifyView.as_view(),
         name='api-token-verify'
     ),
     url(
         r'^api-token-refresh/',
-        TokenRefreshView.as_view(serializer_class=JwtSerializer),
+        TokenRefreshView.as_view(serializer_class=JwtRefreshSerializer),
         name='api-token-refresh'
     ),
     url(r'^v1/', include((router.urls, 'api'), namespace='v1')),

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -328,7 +328,7 @@ SIMPLE_JWT = {
 }
 
 REST_AUTH_SERIALIZERS = {
-    'JWT_TOKEN_CLAIMS_SERIALIZER': 'rovercode_web.users.utils.JwtSerializer',
+    'JWT_TOKEN_CLAIMS_SERIALIZER': 'rovercode_web.users.utils.JwtObtainPairSerializer',
 }
 
 # Enables django-rest-auth to use JWT tokens instead of regular tokens.

--- a/rovercode_web/users/signals/handlers.py
+++ b/rovercode_web/users/signals/handlers.py
@@ -4,7 +4,7 @@ import logging
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from rovercode_web.users.utils import JwtSerializer
+from rovercode_web.users.utils import JwtObtainPairSerializer
 
 import requests
 
@@ -17,7 +17,7 @@ def create_new_user(sender, instance, created, **kwargs):
     if not created:
         return
 
-    token = JwtSerializer.get_token(instance)
+    token = JwtObtainPairSerializer.get_token(instance)
     token['admin'] = True
     auth_jwt = str(token)
 

--- a/rovercode_web/users/tests/test_utils.py
+++ b/rovercode_web/users/tests/test_utils.py
@@ -5,8 +5,10 @@ from django.test import override_settings
 from test_plus.test import TestCase
 
 import responses
+from rest_framework_simplejwt.tokens import RefreshToken
 
-from rovercode_web.users.utils import JwtSerializer
+from rovercode_web.users.utils import JwtObtainPairSerializer
+from rovercode_web.users.utils import JwtRefreshSerializer
 
 
 @override_settings(SUBSCRIPTION_SERVICE_HOST='http://test.test')
@@ -27,7 +29,7 @@ class TestUtils(TestCase):
             f'http://test.test/api/v1/customer/{self.user.id}/',
             status=503
         )
-        payload = JwtSerializer.get_token(self.user)
+        payload = JwtObtainPairSerializer.get_token(self.user)
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(payload['tier'], 1)
 
@@ -40,7 +42,27 @@ class TestUtils(TestCase):
             json={'subscription': {'plan': '2'}},
             status=200
         )
-        payload = JwtSerializer.get_token(self.user)
+        payload = JwtObtainPairSerializer.get_token(self.user)
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(payload['show_guide'], self.user.show_guide)
         self.assertEqual(payload['tier'], 2)
+
+    @responses.activate
+    def test_jwt_refresh_payload(self):
+        """Test refreshing the JWT payload."""
+        responses.add(
+            responses.GET,
+            f'http://test.test/api/v1/customer/{self.user.id}/',
+            json={'subscription': {'plan': '2'}},
+            status=200
+        )
+        refresh_token = RefreshToken.for_user(self.user)
+        refresh_token['show_guide'] = self.user.show_guide
+        serializer = JwtRefreshSerializer(data={
+            'refresh': str(refresh_token),
+        })
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(len(responses.calls), 1)
+        token = RefreshToken(serializer.validated_data['refresh'])
+        self.assertEqual(token['show_guide'], self.user.show_guide)
+        self.assertEqual(token['tier'], 2)

--- a/rovercode_web/users/utils.py
+++ b/rovercode_web/users/utils.py
@@ -3,12 +3,38 @@ import json
 
 from django.conf import settings
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from rest_framework_simplejwt.serializers import TokenRefreshSerializer
+from rest_framework_simplejwt.tokens import RefreshToken
 
 import requests
 
 
+class BaseJwtSerializer:
+    """Base JWT serializer to customize claims."""
+
+    @staticmethod
+    def get_user_tier(user_id, auth_jwt):
+        """Get the user's tier for the subscription service."""
+        subscription_service = settings.SUBSCRIPTION_SERVICE_HOST
+        try:
+            response = requests.get(
+                f'{subscription_service}/api/v1/customer/{user_id}/',
+                headers={'Authorization': f'JWT {auth_jwt}'}
+            )
+            data = response.json()
+            return int(data['subscription']['plan'])
+        except (
+            json.decoder.JSONDecodeError,
+            KeyError,
+            ValueError,
+            requests.exceptions.ConnectionError
+        ):
+            # If unable to determine tier, set to lowest
+            return 1
+
+
 # pylint: disable=abstract-method
-class JwtSerializer(TokenObtainPairSerializer):
+class JwtObtainPairSerializer(BaseJwtSerializer, TokenObtainPairSerializer):
     """Custom serializer to add claims to the token."""
 
     @classmethod
@@ -19,22 +45,22 @@ class JwtSerializer(TokenObtainPairSerializer):
         token['username'] = user.username
 
         user_id = token['user_id']
-        auth_jwt = str(token)
-        subscription_service = settings.SUBSCRIPTION_SERVICE_HOST
-        try:
-            response = requests.get(
-                f'{subscription_service}/api/v1/customer/{user_id}/',
-                headers={'Authorization': f'JWT {auth_jwt}'}
-            )
-            data = response.json()
-            token['tier'] = int(data['subscription']['plan'])
-        except (
-            json.decoder.JSONDecodeError,
-            KeyError,
-            ValueError,
-            requests.exceptions.ConnectionError
-        ):
-            # If unable to determine tier, set to lowest
-            token['tier'] = 1
+        token['tier'] = cls.get_user_tier(user_id, str(token))
 
         return token
+
+
+class JwtRefreshSerializer(BaseJwtSerializer, TokenRefreshSerializer):
+    """Custom serializer to add claims to the token."""
+
+    def validate(self, attrs):
+        """Validate and return a new token."""
+        response = super().validate(attrs)
+
+        refresh = RefreshToken(response['refresh'])
+        refresh['tier'] = self.get_user_tier(refresh['user_id'], str(refresh))
+
+        return {
+            'access': str(refresh.access_token),
+            'refresh': str(refresh),
+        }


### PR DESCRIPTION
Fixes the JWT token refresh and verify views. The wrong serializers had been used when the library was changed. Now the correct parameters are used to refresh or verify the token.