### PR TITLE
Set shell for documentation build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,8 @@ jobs:
         pipenv install --ignore-pipfile --dev
 
     - name: Build documentation
+      env:
+        SHELL: '/bin/bash'
       run: |
         pipenv shell
         make -C docs html


### PR DESCRIPTION
Currently failing with: `Please ensure that the SHELL environment variable is set before activating shell.`. So, this sets `SHELL`