### PR TITLE
Run directly from pipenv

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,9 +46,7 @@ jobs:
     - name: Build documentation
       env:
         SHELL: '/bin/bash'
-      run: |
-        pipenv shell
-        make -C docs html
+      run: make SPHINXBUILD="pipenv run sphinx-build" -C docs html
 
     - name: Deploy documentation
       if: success() && github.ref == 'ref/head/master'


### PR DESCRIPTION
Removes the shell since it does not work properly. Instead, override the command to run the build